### PR TITLE
Make the dockyard able to run

### DIFF
--- a/dockyard/cmd/daemon.go
+++ b/dockyard/cmd/daemon.go
@@ -27,6 +27,7 @@ import (
 	"gopkg.in/macaron.v1"
 
 	"github.com/Huawei/containerops/common"
+	"github.com/Huawei/containerops/dockyard/model"
 	"github.com/Huawei/containerops/dockyard/web"
 )
 
@@ -81,6 +82,7 @@ func init() {
 
 // startDeamon() start Dockyard's REST API daemon.
 func startDeamon(cmd *cobra.Command, args []string) {
+	model.OpenDatabase()
 	m := macaron.New()
 
 	// Set Macaron Web Middleware And Routers

--- a/dockyard/handler/dockerv2.go
+++ b/dockyard/handler/dockerv2.go
@@ -35,6 +35,7 @@ import (
 	"github.com/Huawei/containerops/dockyard/model"
 	"github.com/Huawei/containerops/dockyard/module"
 	"github.com/Huawei/containerops/dockyard/module/signature"
+	"github.com/Huawei/containerops/dockyard/utils"
 )
 
 //GetPingV2Handler is https://github.com/docker/distribution/blob/master/docs/spec/api.md#api-version-check
@@ -110,8 +111,8 @@ func PostBlobsV2Handler(ctx *macaron.Context) (int, []byte) {
 
 	uuid := common.MD5(uuid.NewV4().String())
 	state := common.MD5(fmt.Sprintf("%s/%s/%d", namespace, repository, time.Now().UnixNano()/int64(time.Millisecond)))
-	random := fmt.Sprintf("https://%s/v2/%s/%s/blobs/uploads/%s?_state=%s",
-		"deployment.domains", namespace, repository, uuid, state)
+	random := fmt.Sprintf("%s://%s/v2/%s/%s/blobs/uploads/%s?_state=%s",
+		utils.GetRequestScheme(ctx.Req.Request), ctx.Req.Request.Host, namespace, repository, uuid, state)
 
 	ctx.Resp.Header().Set("Content-Type", "text/plain; charset=utf-8")
 	ctx.Resp.Header().Set("Docker-Upload-Uuid", uuid)
@@ -167,8 +168,8 @@ func PatchBlobsV2Handler(ctx *macaron.Context) (int, []byte) {
 	}
 
 	state := common.MD5(fmt.Sprintf("%s/%v", fmt.Sprintf("%s/%s", namespace, repository), time.Now().UnixNano()/int64(time.Millisecond)))
-	random := fmt.Sprintf("https://%s/v2/%s/%s/blobs/uploads/%s?_state=%s",
-		"deployment.domains", namespace, repository, uuid, state)
+	random := fmt.Sprintf("%s://%s/v2/%s/%s/blobs/uploads/%s?_state=%s",
+		utils.GetRequestScheme(ctx.Req.Request), ctx.Req.Request.Host, namespace, repository, uuid, state)
 
 	ctx.Resp.Header().Set("Content-Type", "text/plain; charset=utf-8")
 	ctx.Resp.Header().Set("Docker-Upload-Uuid", uuid)
@@ -250,8 +251,8 @@ func PutBlobsV2Handler(ctx *macaron.Context) (int, []byte) {
 	}
 
 	state := common.MD5(fmt.Sprintf("%s/%v", fmt.Sprintf("%s/%s", namespace, repository), time.Now().UnixNano()/int64(time.Millisecond)))
-	random := fmt.Sprintf("https://%s/v2/%s/%s/blobs/uploads/%s?_state=%s",
-		"deployment.domains", namespace, repository, uuid, state)
+	random := fmt.Sprintf("%s://%s/v2/%s/%s/blobs/uploads/%s?_state=%s",
+		utils.GetRequestScheme(ctx.Req.Request), ctx.Req.Request.Host, namespace, repository, uuid, state)
 
 	ctx.Resp.Header().Set("Content-Type", "text/plain; charset=utf-8")
 	ctx.Resp.Header().Set("Docker-Content-Digest", digest)
@@ -345,8 +346,8 @@ func PutManifestsV2Handler(ctx *macaron.Context) (int, []byte) {
 			return http.StatusBadRequest, result
 		}
 
-		random := fmt.Sprintf("https://%s/v2/%s/%s/manifests/%s",
-			"deployment.domains", namespace, repository, digest)
+		random := fmt.Sprintf("%s://%s/v2/%s/%s/manifests/%s",
+			utils.GetRequestScheme(ctx.Req.Request), ctx.Req.Request.Host, namespace, repository, digest)
 
 		ctx.Resp.Header().Set("Content-Type", "text/plain; charset=utf-8")
 		ctx.Resp.Header().Set("Docker-Content-Digest", digest)

--- a/dockyard/model/dockerv2.go
+++ b/dockyard/model/dockerv2.go
@@ -17,6 +17,7 @@ limitations under the License.
 package model
 
 import (
+	"sync"
 	"time"
 )
 
@@ -115,6 +116,9 @@ func (r *DockerV2) Put(namespace, repository string) error {
 
 	tx := DB.Begin()
 
+	mutex := &sync.Mutex{}
+	mutex.Lock()
+	defer mutex.Unlock()
 	if err := tx.Debug().Where("namespace = ? AND repository = ? ", namespace, repository).FirstOrCreate(&r).Error; err != nil {
 		tx.Rollback()
 		return err

--- a/dockyard/utils/web.go
+++ b/dockyard/utils/web.go
@@ -1,0 +1,12 @@
+package utils
+
+import "net/http"
+
+// GetRequestScheme Returns the scheme of a http request.
+func GetRequestScheme(r *http.Request) string {
+	scheme := "http"
+	if r.TLS != nil {
+		scheme = "https"
+	}
+	return scheme
+}


### PR DESCRIPTION
- Open database connection when starting daemon, thus avoid the error that DB instance is nil
- Lock the FirstOrCreate operation on DockerV2 model, avoid the 'duplicated index' error
- Return the real http scheme&host in docker registry APIs