### PR TITLE
Read database configs from config file

### DIFF
--- a/dockyard/.gitignore
+++ b/dockyard/.gitignore
@@ -12,3 +12,5 @@
 
 # Project-local glide cache, RE: https://github.com/Masterminds/glide/issues/736
 .glide/
+
+conf/runtime.conf

--- a/dockyard/cmd/common_params.go
+++ b/dockyard/cmd/common_params.go
@@ -1,0 +1,3 @@
+package cmd
+
+var configFilePath string

--- a/dockyard/cmd/daemon.go
+++ b/dockyard/cmd/daemon.go
@@ -23,7 +23,7 @@ import (
 	"net/http"
 	"os"
 
-	log "github.com/jcloudpub/speedy/logs"
+	log "github.com/Sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"gopkg.in/macaron.v1"
 

--- a/dockyard/cmd/daemon.go
+++ b/dockyard/cmd/daemon.go
@@ -23,11 +23,13 @@ import (
 	"net/http"
 	"os"
 
+	log "github.com/jcloudpub/speedy/logs"
 	"github.com/spf13/cobra"
 	"gopkg.in/macaron.v1"
 
 	"github.com/Huawei/containerops/common"
 	"github.com/Huawei/containerops/dockyard/model"
+	"github.com/Huawei/containerops/dockyard/setting"
 	"github.com/Huawei/containerops/dockyard/web"
 )
 
@@ -82,7 +84,12 @@ func init() {
 
 // startDeamon() start Dockyard's REST API daemon.
 func startDeamon(cmd *cobra.Command, args []string) {
-	model.OpenDatabase()
+	if err := setting.SetConfig("./conf/runtime.conf"); err != nil {
+		log.Fatalf("Failed to init settings: %s", err.Error())
+		os.Exit(1)
+	}
+
+	model.OpenDatabase(&setting.DBConfig)
 	m := macaron.New()
 
 	// Set Macaron Web Middleware And Routers

--- a/dockyard/cmd/daemon.go
+++ b/dockyard/cmd/daemon.go
@@ -75,6 +75,7 @@ func init() {
 	daemonCmd.AddCommand(startDaemonCmd)
 	startDaemonCmd.Flags().StringVarP(&address, "address", "a", "0.0.0.0", "http or https listen address.")
 	startDaemonCmd.Flags().Int64VarP(&port, "port", "p", 80, "the port of http.")
+	startDaemonCmd.Flags().StringVarP(&configFilePath, "config", "c", "./conf/runtime.conf", "path of the config file.")
 
 	// Add stop subcommand
 	daemonCmd.AddCommand(stopDaemonCmd)
@@ -84,7 +85,7 @@ func init() {
 
 // startDeamon() start Dockyard's REST API daemon.
 func startDeamon(cmd *cobra.Command, args []string) {
-	if err := setting.SetConfig("./conf/runtime.conf"); err != nil {
+	if err := setting.SetConfig(configFilePath); err != nil {
 		log.Fatalf("Failed to init settings: %s", err.Error())
 		os.Exit(1)
 	}

--- a/dockyard/cmd/database.go
+++ b/dockyard/cmd/database.go
@@ -17,9 +17,12 @@ limitations under the License.
 package cmd
 
 import (
+	log "github.com/Sirupsen/logrus"
+
 	"github.com/spf13/cobra"
 
 	"github.com/Huawei/containerops/dockyard/model"
+	"github.com/Huawei/containerops/dockyard/setting"
 )
 
 // databasecmd is subcommand which migrate/backup/restore Dockyard's database.
@@ -60,10 +63,18 @@ func init() {
 	databaseCmd.AddCommand(migrateDatabaseCmd)
 	databaseCmd.AddCommand(backupDatabaseCmd)
 	databaseCmd.AddCommand(restoreDatabaseCmd)
+
+	migrateDatabaseCmd.Flags().StringVarP(&configFilePath, "config", "c", "./conf/runtime.conf", "path of the config file.")
 }
 
 // migrateDatabase is auto-migrate database of Dockyard.
 func migrateDatabase(cmd *cobra.Command, args []string) {
+	if err := setting.SetConfig(configFilePath); err != nil {
+		log.Fatalf("Failed to init settings: %s", err.Error())
+		return
+	}
+
+	model.OpenDatabase(&setting.DBConfig)
 	model.Migrate()
 }
 

--- a/dockyard/conf/runtime.conf.example
+++ b/dockyard/conf/runtime.conf.example
@@ -1,0 +1,7 @@
+[database]
+driver = "mysql"
+host = "127.0.0.1"
+port = "3306"
+user = "root"
+password = "mypassword"
+db = 'containerops_dockyard'

--- a/dockyard/conf/runtime.conf.example
+++ b/dockyard/conf/runtime.conf.example
@@ -3,5 +3,5 @@ driver = "mysql"
 host = "127.0.0.1"
 port = "3306"
 user = "root"
-password = "mypassword"
+password = "containerops_dockyard_password"
 db = 'containerops_dockyard'

--- a/dockyard/model/model.go
+++ b/dockyard/model/model.go
@@ -17,8 +17,10 @@ limitations under the License.
 package model
 
 import (
+	"fmt"
 	"os"
 
+	"github.com/Huawei/containerops/dockyard/setting"
 	log "github.com/Sirupsen/logrus"
 	"github.com/jinzhu/gorm"
 )
@@ -33,10 +35,12 @@ func init() {
 }
 
 // OpenDatabase is
-func OpenDatabase() {
+func OpenDatabase(dbconfig *setting.DatabaseConfig) {
+	driver, host, port, user, password, db := dbconfig.Driver, dbconfig.Host, dbconfig.Port, dbconfig.User, dbconfig.Password, dbconfig.Name
 	var err error
-	if DB, err = gorm.Open("database.driver", "database.uri"); err != nil {
-		log.Fatal("Initlization database connection error.")
+	dsn := fmt.Sprintf("%s:%s@tcp(%s:%s)/%s?parseTime=True&loc=Local", user, password, host, port, db)
+	if DB, err = gorm.Open(driver, dsn); err != nil {
+		log.Fatal("Initlization database connection error.", err)
 		os.Exit(1)
 	} else {
 		DB.DB()
@@ -49,7 +53,11 @@ func OpenDatabase() {
 
 // Migrate is
 func Migrate() {
-	OpenDatabase()
+	if err := setting.SetConfig("./conf/runtime.conf"); err != nil {
+		log.Fatalf("Failed to init settings: %s", err.Error())
+		return
+	}
+	OpenDatabase(&setting.DBConfig)
 
 	DB.AutoMigrate(&DockerV2{}, &DockerImageV2{}, &DockerTagV2{})
 

--- a/dockyard/model/model.go
+++ b/dockyard/model/model.go
@@ -53,12 +53,6 @@ func OpenDatabase(dbconfig *setting.DatabaseConfig) {
 
 // Migrate is
 func Migrate() {
-	if err := setting.SetConfig("./conf/runtime.conf"); err != nil {
-		log.Fatalf("Failed to init settings: %s", err.Error())
-		return
-	}
-	OpenDatabase(&setting.DBConfig)
-
 	DB.AutoMigrate(&DockerV2{}, &DockerImageV2{}, &DockerTagV2{})
 
 	log.Info("Auto Migrate Dockyard Database Structs Done.")

--- a/dockyard/setting/setting.go
+++ b/dockyard/setting/setting.go
@@ -1,0 +1,42 @@
+// Package setting
+package setting
+
+import (
+	"encoding/json"
+
+	"github.com/spf13/viper"
+)
+
+func SetConfig(configPath string) error {
+	viper.SetConfigType("toml")
+	viper.SetConfigFile(configPath)
+	err := viper.ReadInConfig()
+	if err != nil {
+		return err
+	}
+
+	if err := setDatabaseConfig(viper.GetStringMap("database")); err != nil {
+		return err
+	}
+	return nil
+}
+
+type DatabaseConfig struct {
+	Driver   string `json:"driver"`
+	Host     string `json:"host"`
+	Port     string `json:"port"`
+	User     string `json:"user"`
+	Password string `json:"password"`
+	Name     string `json:"db"`
+}
+
+var DBConfig DatabaseConfig
+
+func setDatabaseConfig(config map[string]interface{}) error {
+	bs, err := json.Marshal(&config)
+	if err != nil {
+		return err
+	}
+
+	return json.Unmarshal(bs, &DBConfig)
+}


### PR DESCRIPTION
When starting the daemon or migrating the database, dockyard command read the config file whose path is specified by --config parameter. The config file is in toml format that contains only one section 'database' like this:
```
[database]
driver = "mysql" #only support MySQL for now
host = "127.0.0.1"
port = "3306" #port should be in string format
user = "root"
password = "root"
db = 'containerops_dockyard'
```
