### PR TITLE
Add graceful shutdown functionality

### DIFF
--- a/dockyard/.gitignore
+++ b/dockyard/.gitignore
@@ -13,4 +13,4 @@
 # Project-local glide cache, RE: https://github.com/Masterminds/glide/issues/736
 .glide/
 
-conf/runtime.conf
+conf/runtime.toml

--- a/dockyard/README.md
+++ b/dockyard/README.md
@@ -4,6 +4,64 @@
 
 ### The Dockyard's Story :)
 
-The Dockyard is my startup project before joined Huawei in April 2015, and then I donated to Huawei company. Now the git repository in the Huawei organization in Github. The Dockyard is a combo included container registry and artifact repository. It is an important part of any DevOps process, even more in ContainerOps which is a container's implement of DevOps Orchestration.
+The Dockyard is my startup project before joining Huawei in April 2015, after that I donated it to Huawei company. Now the git repository is in the Huawei organization on Github. The Dockyard is a combo storage service including container registry and artifact repository. The storage of docker images and binary files is an important part of any DevOps process, it's even more important in ContainerOps, which is a DevOps Orchestration engine powered by containers.
 
-The version of Dockyard in the ContainerOps repository is the minimal functions of Dockyard project, and we will continuous develop it as the next release. The repository in the Huawei organization is freezing for a while, and this version migrates to the repository finally in the feature.
+The version of Dockyard in the ContainerOps repository is shipped with the minimal functions, and we will develop it continuously as the next release. The repository in the Huawei organization is frozen for a while, and this version will be migrated to the repository finally in the feature.
+
+
+### Getting started
+
+#### Notice! Dockyard only support Golang 1.8 or above!
+Since we introduced [graceful shutdown](https://beta.golang.org/doc/go1.8#http_shutdown), the new feature of Golang 1.8, the source code SHOUL be built with Go 1.8 or higher. If you really need to compile it in a former Go version, just find the incompatible code and delete them in `cmd/daemon.go` :)
+
+#### Initialize the database
+Dockyard starts with a database(currently we only support MySQL):
+``` bash
+CREATE DATABASE containerops_dockyard DEFAULT CHARACTER SET utf8 COLLATE utf8_bin;
+```
+And then call the `database` subcommand with action `migrate`:
+``` bash
+./dockyard database migrate
+```
+
+#### Start dockyard daemon
+Now all the tables are created, you can start the daemon by:
+``` bash
+./dockyard daemon start
+```
+
+#### The config file
+Dockyard reads the configs from a `.toml` file. You can specify the config file path with option `-c` or `--config`:
+``` bash
+./dockyard daemon start -c PATH_TO_CONFIG
+```
+
+If the path is not given, dockyard will take the default path `./conf/runtime.toml`
+
+A config file is like this(you can find it under `./conf/runtime.toml.example`):
+
+```toml
+[database]
+driver = "mysql"
+host = "127.0.0.1"
+port = 3306
+user = "root"
+password = "root"
+db = 'containerops_dockyard'
+
+[web]
+address = "127.0.0.1"
+port = 8990
+cert = "./cert/nginx.crt" #dockyard support only https!
+key = "./cert/nginx.key"
+```
+
+You can also override the address and port by passing command line arguments:
+``` bash
+./dockyard daemon start -p 8990 -a 127.0.0.1
+```
+
+For more details of the command line arguments, just type the sub command without any action:
+```
+./dockyard daemon
+```

--- a/dockyard/cmd/database.go
+++ b/dockyard/cmd/database.go
@@ -64,7 +64,7 @@ func init() {
 	databaseCmd.AddCommand(backupDatabaseCmd)
 	databaseCmd.AddCommand(restoreDatabaseCmd)
 
-	migrateDatabaseCmd.Flags().StringVarP(&configFilePath, "config", "c", "./conf/runtime.conf", "path of the config file.")
+	migrateDatabaseCmd.Flags().StringVarP(&configFilePath, "config", "c", "./conf/runtime.toml", "path of the config file.")
 }
 
 // migrateDatabase is auto-migrate database of Dockyard.

--- a/dockyard/cmd/database.go
+++ b/dockyard/cmd/database.go
@@ -74,7 +74,7 @@ func migrateDatabase(cmd *cobra.Command, args []string) {
 		return
 	}
 
-	model.OpenDatabase(&setting.DBConfig)
+	model.OpenDatabase(&setting.Database)
 	model.Migrate()
 }
 

--- a/dockyard/conf/runtime.conf.example
+++ b/dockyard/conf/runtime.conf.example
@@ -1,7 +1,0 @@
-[database]
-driver = "mysql"
-host = "127.0.0.1"
-port = "3306"
-user = "root"
-password = "containerops_dockyard_password"
-db = 'containerops_dockyard'

--- a/dockyard/conf/runtime.toml.example
+++ b/dockyard/conf/runtime.toml.example
@@ -7,16 +7,8 @@ password = "containerops_dockyard_password"
 db = 'containerops_dockyard'
 
 # Configs for daemon sub command
-[listenmode]
-mode = "http"
+[web]
 address = "127.0.0.1"
-port = 8990
-#
-# mode = "https"
-# address = "127.0.0.1"
-# port = 443
-# cert = "PATH_TO_CERT_FILE"
-# key = "PATH_TO_KEY_FILE"
-#
-# mode = "unix"
-# address = "/var/run/dockyard.sock"
+port = 443
+cert = "PATH_TO_CERT_FILE"
+key = "PATH_TO_KEY_FILE"

--- a/dockyard/conf/runtime.toml.example
+++ b/dockyard/conf/runtime.toml.example
@@ -1,0 +1,22 @@
+[database]
+driver = "mysql"
+host = "127.0.0.1"
+port = 3306
+user = "root"
+password = "containerops_dockyard_password"
+db = 'containerops_dockyard'
+
+# Configs for daemon sub command
+[listenmode]
+mode = "http"
+address = "127.0.0.1"
+port = 8990
+#
+# mode = "https"
+# address = "127.0.0.1"
+# port = 443
+# cert = "PATH_TO_CERT_FILE"
+# key = "PATH_TO_KEY_FILE"
+#
+# mode = "unix"
+# address = "/var/run/dockyard.sock"

--- a/dockyard/model/dockerv2.go
+++ b/dockyard/model/dockerv2.go
@@ -119,7 +119,7 @@ func (r *DockerV2) Put(namespace, repository string) error {
 	mutex := &sync.Mutex{}
 	mutex.Lock()
 	defer mutex.Unlock()
-	if err := tx.Debug().Where("namespace = ? AND repository = ? ", namespace, repository).FirstOrCreate(&r).Error; err != nil {
+	if err := tx.Debug().Where("namespace = ? AND repository = ? ", namespace, repository).FirstOrCreate(r).Error; err != nil {
 		tx.Rollback()
 		return err
 	}
@@ -165,7 +165,7 @@ func (i *DockerImageV2) Put(tarsum, path string, size int64) error {
 
 	tx := DB.Begin()
 
-	if err := tx.Debug().Where("blob_sum = ? ", tarsum).FirstOrCreate(&i).Error; err != nil {
+	if err := tx.Debug().Where("blob_sum = ? ", tarsum).FirstOrCreate(i).Error; err != nil {
 		tx.Rollback()
 		return err
 	}

--- a/dockyard/model/model.go
+++ b/dockyard/model/model.go
@@ -38,7 +38,7 @@ func init() {
 func OpenDatabase(dbconfig *setting.DatabaseConfig) {
 	driver, host, port, user, password, db := dbconfig.Driver, dbconfig.Host, dbconfig.Port, dbconfig.User, dbconfig.Password, dbconfig.Name
 	var err error
-	dsn := fmt.Sprintf("%s:%s@tcp(%s:%s)/%s?parseTime=True&loc=Local", user, password, host, port, db)
+	dsn := fmt.Sprintf("%s:%s@tcp(%s:%d)/%s?parseTime=True&loc=Local", user, password, host, port, db)
 	if DB, err = gorm.Open(driver, dsn); err != nil {
 		log.Fatal("Initlization database connection error.", err)
 		os.Exit(1)

--- a/dockyard/setting/setting.go
+++ b/dockyard/setting/setting.go
@@ -3,7 +3,6 @@ package setting
 
 import (
 	"encoding/json"
-	"fmt"
 
 	"github.com/spf13/viper"
 )
@@ -20,7 +19,7 @@ func SetConfig(configPath string) error {
 		return err
 	}
 
-	if err := setListenMode(viper.GetStringMap("listenmode")); err != nil {
+	if err := setWebConfig(viper.GetStringMap("web")); err != nil {
 		return err
 	}
 
@@ -36,16 +35,15 @@ type DatabaseConfig struct {
 	Name     string `json:"db"`
 }
 
-type ListenModeConfig struct {
-	Mode    string `json:"mode"`
+type WebConfig struct {
 	Address string `json:"address"`
 	Port    int    `json:"port"`
-	CertKey string `json:"key"`
+	Key     string `json:"key"`
 	Cert    string `json:"cert"`
 }
 
 var Database DatabaseConfig
-var ListenMode ListenModeConfig
+var Web WebConfig
 
 func setDatabaseConfig(config map[string]interface{}) error {
 	bs, err := json.Marshal(&config)
@@ -56,19 +54,15 @@ func setDatabaseConfig(config map[string]interface{}) error {
 	return json.Unmarshal(bs, &Database)
 }
 
-func setListenMode(config map[string]interface{}) error {
+func setWebConfig(config map[string]interface{}) error {
 	bs, err := json.Marshal(&config)
 	if err != nil {
 		return err
 	}
 
-	err = json.Unmarshal(bs, &ListenMode)
+	err = json.Unmarshal(bs, &Web)
 	if err != nil {
 		return err
-	}
-
-	if ListenMode.Mode != "http" && ListenMode.Mode != "https" && ListenMode.Mode != "unix" {
-		return fmt.Errorf("Invalid listen mode: %s", ListenMode.Mode)
 	}
 
 	return nil

--- a/dockyard/setting/setting.go
+++ b/dockyard/setting/setting.go
@@ -3,6 +3,7 @@ package setting
 
 import (
 	"encoding/json"
+	"fmt"
 
 	"github.com/spf13/viper"
 )
@@ -18,19 +19,33 @@ func SetConfig(configPath string) error {
 	if err := setDatabaseConfig(viper.GetStringMap("database")); err != nil {
 		return err
 	}
+
+	if err := setListenMode(viper.GetStringMap("listenmode")); err != nil {
+		return err
+	}
+
 	return nil
 }
 
 type DatabaseConfig struct {
 	Driver   string `json:"driver"`
 	Host     string `json:"host"`
-	Port     string `json:"port"`
+	Port     int    `json:"port"`
 	User     string `json:"user"`
 	Password string `json:"password"`
 	Name     string `json:"db"`
 }
 
-var DBConfig DatabaseConfig
+type ListenModeConfig struct {
+	Mode    string `json:"mode"`
+	Address string `json:"address"`
+	Port    int    `json:"port"`
+	CertKey string `json:"key"`
+	Cert    string `json:"cert"`
+}
+
+var Database DatabaseConfig
+var ListenMode ListenModeConfig
 
 func setDatabaseConfig(config map[string]interface{}) error {
 	bs, err := json.Marshal(&config)
@@ -38,5 +53,23 @@ func setDatabaseConfig(config map[string]interface{}) error {
 		return err
 	}
 
-	return json.Unmarshal(bs, &DBConfig)
+	return json.Unmarshal(bs, &Database)
+}
+
+func setListenMode(config map[string]interface{}) error {
+	bs, err := json.Marshal(&config)
+	if err != nil {
+		return err
+	}
+
+	err = json.Unmarshal(bs, &ListenMode)
+	if err != nil {
+		return err
+	}
+
+	if ListenMode.Mode != "http" && ListenMode.Mode != "https" && ListenMode.Mode != "unix" {
+		return fmt.Errorf("Invalid listen mode: %s", ListenMode.Mode)
+	}
+
+	return nil
 }


### PR DESCRIPTION
Add the [graceful shutdown](https://beta.golang.org/doc/go1.8#http_shutdown) functionality which is introduced in Golang 1.8

Remove the support of listening HTTP port and Unix file.

Update the README, add the section of 'Getting started'