### PR TITLE
[dockyard]Fix errors & update README.md

### DIFF
--- a/dockyard/README.md
+++ b/dockyard/README.md
@@ -31,9 +31,9 @@ Now all the tables are created, you can start the daemon by:
 ```
 
 #### The config file
-Dockyard reads the configs from a `.toml` file. You can specify the config file path with option `-c` or `--config`:
+Dockyard reads the configs from a `.toml` file. You can specify the config file path with option or `--config`:
 ``` bash
-./dockyard daemon start -c PATH_TO_CONFIG
+./dockyard daemon start --config PATH_TO_CONFIG
 ```
 
 If the path is not given, dockyard will take the default path `./conf/runtime.toml`
@@ -70,4 +70,27 @@ You can also override the address and port by passing command line arguments:
 For more details of the command line arguments, just type the sub command without any action:
 ```
 ./dockyard daemon
+```
+
+### Put dockyard behind a proxy server
+You might put dockyard behind a proxy server(like Nginx, Caddy etc.), because of the design of docker registry API, you'll have to take care of the header forwarding, you should pass the `scheme` and `host` headers to dockyard, or dockyard might not work as expected. 
+
+What's more, since most of the proxy servers would have a default request body size limit, it's better to make it larger.
+
+The example of a nginx config:
+```
+    server {
+      listen    443;
+      server_name    containerops.io;
+      ssl on;
+      ssl_certificate ssl/containerops.crt;
+      ssl_certificate_key ssl/containerops.key;
+
+      client_max_body_size 200M;  # Set it as you wish
+      location / {
+        proxy_pass    http://unix:/var/run/dockyard.socket;
+        proxy_set_header X-Forwarded-Proto $scheme; # This is essential for nginx!
+        proxy_set_header Host $http_host;  # This is essential for nginx!
+      }
+    }
 ```

--- a/dockyard/handler/dockerv2.go
+++ b/dockyard/handler/dockerv2.go
@@ -293,7 +293,6 @@ func GetBlobsV2Handler(ctx *macaron.Context) {
 		defer file.Close()
 
 		io.Copy(ctx.Resp, file)
-		ctx.Resp.WriteHeader(http.StatusOK)
 		return
 	}
 }

--- a/dockyard/model/dockerv2.go
+++ b/dockyard/model/dockerv2.go
@@ -112,16 +112,16 @@ func (r *DockerV2) Get(namespace, repository string) error {
 	return nil
 }
 
+var dockerv2Mutex sync.Mutex
+
 // Put is
 func (r *DockerV2) Put(namespace, repository string) error {
 	r.Namespace, r.Repository = namespace, repository
 
+	dockerv2Mutex.Lock()
+	defer dockerv2Mutex.Unlock()
+
 	tx := DB.Begin()
-
-	mutex := &sync.Mutex{}
-	mutex.Lock()
-	defer mutex.Unlock()
-
 	if err := tx.Debug().Where("namespace = ? AND repository = ? ", namespace, repository).FirstOrCreate(&r).Error; err != nil {
 		tx.Rollback()
 		return err


### PR DESCRIPTION
- Fix the error of duplicate index when creating docker_v2 record
- Fix the error of multiple response.WriteHeader calls when pulling layer
- Update the README file, add the section of 'put dockyard behind a proxy server'