### PR TITLE
add pylint componet

### DIFF
--- a/component/images/python/pylint/Dockerfile
+++ b/component/images/python/pylint/Dockerfile
@@ -1,0 +1,35 @@
+# Copyright 2016 - 2017 Huawei Technologies Co., Ltd. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM containerops/golang:1.8.1
+MAINTAINER thomas.tan <tanhaijun@huawei.com>
+
+# install python(2.7.12) pylint(1.5.2)
+RUN apt-get update && apt-get install -y python python-dev python-pip python-virtualenv pylint
+
+# bulid pylint component
+RUN mkdir -p $GOPATH/src/github.com/Huawei/containerops/
+ADD src/copspylint.go $GOPATH/src/github.com/Huawei/containerops/
+ADD src/pylint.conf $GOPATH/src/github.com/Huawei/containerops/
+
+ENV PATH /user/bin:$GOPATH/src/github.com/Huawei/containerops:$PATH
+
+# defualut pylint.conf generate by cmd "pylint --generate-rcfile > pylint.conf"
+# and modify set reoprts=no
+ENV LINTCONFFILE $GOPATH/src/github.com/Huawei/containerops/pylint.conf
+
+WORKDIR $GOPATH/src/github.com/Huawei/containerops
+RUN go build -o copspylint copspylint.go
+
+CMD copspylint

--- a/component/images/python/pylint/Dockerfile
+++ b/component/images/python/pylint/Dockerfile
@@ -26,7 +26,6 @@ ADD src/pylint.conf $GOPATH/src/github.com/Huawei/containerops/
 ENV PATH /user/bin:$GOPATH/src/github.com/Huawei/containerops:$PATH
 
 # defualut pylint.conf generate by cmd "pylint --generate-rcfile > pylint.conf"
-# and modify set reoprts=no
 ENV LINTCONFFILE $GOPATH/src/github.com/Huawei/containerops/pylint.conf
 
 WORKDIR $GOPATH/src/github.com/Huawei/containerops

--- a/component/images/python/pylint/README.md
+++ b/component/images/python/pylint/README.md
@@ -19,11 +19,11 @@ Output result:
 [COUT] CO_TEST = coderepo=https://github.com/haijunTan/pyhello.git
 Cloning into '/var/opt/gopath/src/tmp'...
 ------------------------------
-[COUT] Start lint file：/var/opt/gopath/src/tmp/pylinttest/pylintnowarning.py
-[COUT] Pylint table1 isn't any warning
-[COUT] End lint file：/var/opt/gopath/src/tmp/pylinttest/pylintnowarning.py end
+[COUT] Start lint file：pylinttest/pylintnowarning.py
+[COUT] pylinttest/pylintnowarning.py isn't any warning
+[COUT] End lint file：pylinttest/pylintnowarning.py end
 ------------------------------
-[COUT] Start lint file：/var/opt/gopath/src/tmp/pylinttest/pylinttest.py
+[COUT] Start lint file：pylinttest/pylinttest.py
 ************* Module pylinttest
 W:  3, 0: Found indentation with tabs instead of spaces (mixed-indentation)
 C:  3, 0: Unnecessary parens after 'print' keyword (superfluous-parens)
@@ -35,9 +35,9 @@ C:  2, 0: Missing function docstring (missing-docstring)
 C:  5, 0: Missing function docstring (missing-docstring)
 C:  7, 1: Invalid variable name "x" (invalid-name)
 W:  7, 1: Unused variable 'x' (unused-variable)
-[COUT] End lint file：/var/opt/gopath/src/tmp/pylinttest/pylinttest.py end
+[COUT] End lint file：pylinttest/pylinttest.py end
 ------------------------------
-[COUT] Start lint file：/var/opt/gopath/src/tmp/pylinttest/pylinttest1.py
+[COUT] Start lint file：pylinttest/pylinttest1.py
 ************* Module pylinttest1
 W:  3, 0: Found indentation with tabs instead of spaces (mixed-indentation)
 C:  3, 0: Unnecessary parens after 'print' keyword (superfluous-parens)
@@ -53,6 +53,6 @@ W:  4, 1: Unused variable 'unusevary' (unused-variable)
 C:  6, 0: Missing function docstring (missing-docstring)
 C:  9, 0: Missing function docstring (missing-docstring)
 W: 10, 1: Unused variable 'unusevarx' (unused-variable)
-[COUT] End lint file：/var/opt/gopath/src/tmp/pylinttest/pylinttest1.py end
+[COUT] End lint file：pylinttest/pylinttest1.py end
 [COUT] CO_RESULT = true
 ```

--- a/component/images/python/pylint/README.md
+++ b/component/images/python/pylint/README.md
@@ -1,4 +1,4 @@
-## Build, Release pylint component
+## Build pylint component
 
 ```bash
 docker build -t containerops/pylint .
@@ -7,23 +7,25 @@ docker build -t containerops/pylint .
 
 ## Set pylint parameter
 ```bash
-The default pylint prameter in contianerops/component/images/python/pylint/src/pylint.conf.   
+1.The default pylint prameter in contianerops/component/images/python/pylint/src/pylint.conf.   
 You can modify it befor build the component.
+2.You can modify the lint parameter via set the environment variable "CO_LINTPARA" by run the componet
 ```
 
 ## Run and test pylint component
 ```bash
-docker run --env CO_CODERPO="coderepo=https://github.com/haijunTan/pyhello.git"  containerops/pylint:latest
+docker run --env CO_CODERPO="coderepo=https://github.com/haijunTan/pyhello.git" --evn  --env CO_LINTPARA="--reports=no" containerops/pylint:latest
 
 Output result:
 [COUT] CO_TEST = coderepo=https://github.com/haijunTan/pyhello.git
 Cloning into '/var/opt/gopath/src/tmp'...
+[COUT] Get input pylint prameter is "--reports=no",and other is default
 ------------------------------
 [COUT] Start lint file：pylinttest/pylintnowarning.py
-[COUT] pylinttest/pylintnowarning.py isn't any warning
 [COUT] End lint file：pylinttest/pylintnowarning.py end
 ------------------------------
 [COUT] Start lint file：pylinttest/pylinttest.py
+[COUT] pylinttest/pylintnowarning.py isn't any warning
 ************* Module pylinttest
 W:  3, 0: Found indentation with tabs instead of spaces (mixed-indentation)
 C:  3, 0: Unnecessary parens after 'print' keyword (superfluous-parens)

--- a/component/images/python/pylint/README.md
+++ b/component/images/python/pylint/README.md
@@ -14,7 +14,7 @@ You can modify it befor build the component.
 
 ## Run and test pylint component
 ```bash
-docker run --env CO_CODERPO="coderepo=https://github.com/haijunTan/pyhello.git" --evn  --env CO_LINTPARA="--reports=no" containerops/pylint:latest
+docker run --env CO_CODERPO="coderepo=https://github.com/haijunTan/pyhello.git" --evn CO_LINTPARA="--reports=no" containerops/pylint:latest
 
 Output result:
 [COUT] CO_TEST = coderepo=https://github.com/haijunTan/pyhello.git

--- a/component/images/python/pylint/README.md
+++ b/component/images/python/pylint/README.md
@@ -1,0 +1,58 @@
+## Build, Release pylint component
+
+```bash
+docker build -t containerops/pylint .
+(workdir:contianerops/component/images/python/pylint)
+```
+
+## Set pylint parameter
+```bash
+The default pylint prameter in contianerops/component/images/python/pylint/src/pylint.conf.   
+You can modify it befor build the component.
+```
+
+## Run and test pylint component
+```bash
+docker run --env CO_CODERPO="coderepo=https://github.com/haijunTan/pyhello.git"  containerops/pylint:latest
+
+Output result:
+[COUT] CO_TEST = coderepo=https://github.com/haijunTan/pyhello.git
+Cloning into '/var/opt/gopath/src/tmp'...
+------------------------------
+[COUT] Start lint file：/var/opt/gopath/src/tmp/pylinttest/pylintnowarning.py
+[COUT] Pylint table1 isn't any warning
+[COUT] End lint file：/var/opt/gopath/src/tmp/pylinttest/pylintnowarning.py end
+------------------------------
+[COUT] Start lint file：/var/opt/gopath/src/tmp/pylinttest/pylinttest.py
+************* Module pylinttest
+W:  3, 0: Found indentation with tabs instead of spaces (mixed-indentation)
+C:  3, 0: Unnecessary parens after 'print' keyword (superfluous-parens)
+W:  6, 0: Found indentation with tabs instead of spaces (mixed-indentation)
+W:  7, 0: Found indentation with tabs instead of spaces (mixed-indentation)
+W: 10, 0: Found indentation with tabs instead of spaces (mixed-indentation)
+C:  1, 0: Missing module docstring (missing-docstring)
+C:  2, 0: Missing function docstring (missing-docstring)
+C:  5, 0: Missing function docstring (missing-docstring)
+C:  7, 1: Invalid variable name "x" (invalid-name)
+W:  7, 1: Unused variable 'x' (unused-variable)
+[COUT] End lint file：/var/opt/gopath/src/tmp/pylinttest/pylinttest.py end
+------------------------------
+[COUT] Start lint file：/var/opt/gopath/src/tmp/pylinttest/pylinttest1.py
+************* Module pylinttest1
+W:  3, 0: Found indentation with tabs instead of spaces (mixed-indentation)
+C:  3, 0: Unnecessary parens after 'print' keyword (superfluous-parens)
+W:  4, 0: Found indentation with tabs instead of spaces (mixed-indentation)
+W:  7, 0: Found indentation with tabs instead of spaces (mixed-indentation)
+C:  7, 0: Unnecessary parens after 'print' keyword (superfluous-parens)
+W: 10, 0: Found indentation with tabs instead of spaces (mixed-indentation)
+W: 11, 0: Found indentation with tabs instead of spaces (mixed-indentation)
+W: 14, 0: Found indentation with tabs instead of spaces (mixed-indentation)
+C:  1, 0: Missing module docstring (missing-docstring)
+C:  2, 0: Missing function docstring (missing-docstring)
+W:  4, 1: Unused variable 'unusevary' (unused-variable)
+C:  6, 0: Missing function docstring (missing-docstring)
+C:  9, 0: Missing function docstring (missing-docstring)
+W: 10, 1: Unused variable 'unusevarx' (unused-variable)
+[COUT] End lint file：/var/opt/gopath/src/tmp/pylinttest/pylinttest1.py end
+[COUT] CO_RESULT = true
+```

--- a/component/images/python/pylint/src/copspylint.go
+++ b/component/images/python/pylint/src/copspylint.go
@@ -1,0 +1,154 @@
+/*
+Copyright 2016 - 2017 Huawei Technologies Co., Ltd. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path"
+	"strings"
+	"path/filepath"
+)
+
+//Parse CO_CODERPO value, and return lintcode repository URI.
+func parseReopEnv(env string) (url string, err error) {
+	files := strings.Fields(env)
+	if len(files) == 0 {
+		return "", fmt.Errorf("CO_CODERPO value is null\n")
+	}
+
+	for _, v := range files {
+		s := strings.Split(v, "=")
+		key, value := s[0], s[1]
+
+		switch key {
+		case "coderepo":
+			url = value
+		default:
+			fmt.Fprintf(os.Stdout, "[COUT] Unknown Parameter: [%s]\n", s)
+		}
+	}
+	return url, nil
+}
+
+//Git clone the code repository, and process will redirect to system stdout.
+func gitClone(repo, dest string) error {
+	cmd := exec.Command("git", "clone", repo, dest)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	if err := cmd.Run(); err != nil {
+		fmt.Fprintf(os.Stderr, "[COUT] Git clone error: %s\n", err.Error())
+		fmt.Fprintf(os.Stdout, "[COUT] CO_RESULT = %s\n", "false")
+		os.Exit(1)
+	}
+
+	return nil
+}
+
+// get all needed lint python source filepath
+func getFilelist(path string)(pyfilelist [] string, err error) {
+  reterr := filepath.Walk(path, func(path string, f os.FileInfo, err error) error {
+    if ( f == nil ) {return nil}
+    if f.IsDir() {return nil}
+    if strings.Contains(path, ".py") == true{
+      pyfilelist = append(pyfilelist, path)
+    }
+    return nil
+    })
+
+  if reterr != nil {
+    fmt.Printf("filepath.Walk() returned %v\n", reterr)
+		os.Exit(1)
+  }
+  return pyfilelist, nil
+}
+
+//execute pylint
+func execPylint(path string) error{
+	//get all python source files needed linted
+	pyfilelist, err := getFilelist(path)
+	if err != nil{
+		fmt.Fprintf(os.Stderr, "[COUT] GetFilelist error = %s\n", err.Error())
+		os.Exit(1)
+	}
+
+	//get pylint rcfile, from environment parameter "CO_CODERPO" in pylintcomponet Dockerfile.
+	//user can modify the lint configs in containerops/component/images/python/pylint/src/pylint.conf
+	rcfile := os.Getenv("LINTCONFFILE")
+	if _, err := os.Stat(rcfile); os.IsNotExist(err) {
+		fmt.Fprintf(os.Stdout, "[COUT] lint rcfile not exist, use default config \n")
+	}
+
+	//lint every python source file
+	for _, table1 := range pyfilelist {
+		fmt.Fprintf(os.Stdout, "------------------------------\n")
+		fmt.Fprintf(os.Stdout, "[COUT] Start lint file：%s\n",table1)
+		cmdpylint := exec.Command("pylint", "--rcfile=" + rcfile, table1)
+		cmdpylint.Stdout = os.Stdout
+		cmdpylint.Stderr = os.Stderr
+		//pylint err return nil when source code hasn't any warrning or err. 
+		if err := cmdpylint.Run(); err == nil {
+			fmt.Fprintf(os.Stderr, "[COUT] Pylint table1 isn't any warning\n")
+		}
+		fmt.Fprintf(os.Stdout, "[COUT] End lint file：%s end\n", table1)
+	}
+
+	return nil
+}
+
+func main() {
+	//Get the CO_CODERPO from environment parameter "CO_CODERPO"
+	repodata := os.Getenv("CO_CODERPO")
+	if len(repodata) == 0 {
+		fmt.Fprintf(os.Stderr, "[COUT] %s\n", "The CO_CODERPO value is null.")
+		fmt.Fprintf(os.Stdout, "[COUT] CO_RESULT = %s\n", "false")
+		os.Exit(1)
+	}
+	fmt.Fprintf(os.Stdout, "[COUT] CO_TEST = %s\n", repodata)
+
+	//Parse the CO_CODERPO, get the lintcode repository URI and action
+	if codeRepo, err := parseReopEnv(repodata); err != nil {
+		fmt.Fprintf(os.Stderr, "[COUT] Parse the CO_CODERPO error: %s\n", err.Error())
+		fmt.Fprintf(os.Stdout, "[COUT] CO_RESULT = %s\n", "false")
+		os.Exit(1)
+	} else {
+		//Create the base path within GOPATH.
+		basePath := path.Join(os.Getenv("GOPATH"), "src","tmp")
+		//Clone the git repository
+		if err := gitClone(codeRepo, basePath); err != nil {
+			fmt.Fprintf(os.Stderr, "[COUT] Clone the code repository error: %s\n", err.Error())
+			fmt.Fprintf(os.Stdout, "[COUT] CO_RESULT = %s\n", "false")
+			os.Exit(1)
+		}
+
+		//Execute pylint
+		if err := execPylint(basePath); err != nil{
+			fmt.Fprintf(os.Stderr, "[COUT] Exec pylint error: %s\n", err.Error())
+			fmt.Fprintf(os.Stdout, "[COUT] CO_RESULT = %s\n", "false")
+			os.Exit(1)
+		}
+	}
+
+	//Print result
+	fmt.Fprintf(os.Stdout, "[COUT] CO_RESULT = %s\n", "true")
+	os.Exit(0)
+}
+
+// Author: tanhaijun@huawei.com
+// 2017-7-17 Create

--- a/component/images/python/pylint/src/copspylint.go
+++ b/component/images/python/pylint/src/copspylint.go
@@ -79,6 +79,16 @@ func getFilelist(path string)(pyfilelist [] string, err error) {
   return pyfilelist, nil
 }
 
+//lint source file save in dir:path.Join(os.Getenv("GOPATH"), "src","tmp")
+//just show the Path after "GOPATH/src/tmp/"  for user
+func userOrigFilePath(lintfilepath string) (originFilePath string){
+	start := strings.Index(lintfilepath,"tmp")
+	len := len(lintfilepath)
+	rstring := []rune(lintfilepath)
+	// start is frist "tmp/" start Site,so we plus 4,get path after tmp/
+	return string(rstring[start+4:len])
+}
+
 //execute pylint
 func execPylint(path string) error{
 	//get all python source files needed linted
@@ -98,15 +108,15 @@ func execPylint(path string) error{
 	//lint every python source file
 	for _, table1 := range pyfilelist {
 		fmt.Fprintf(os.Stdout, "------------------------------\n")
-		fmt.Fprintf(os.Stdout, "[COUT] Start lint file：%s\n",table1)
+		fmt.Fprintf(os.Stdout, "[COUT] Start lint file：%s\n", userOrigFilePath(table1))
 		cmdpylint := exec.Command("pylint", "--rcfile=" + rcfile, table1)
 		cmdpylint.Stdout = os.Stdout
 		cmdpylint.Stderr = os.Stderr
-		//pylint err return nil when source code hasn't any warrning or err. 
+		//pylint err return nil when source code hasn't any warrning or err.
 		if err := cmdpylint.Run(); err == nil {
-			fmt.Fprintf(os.Stderr, "[COUT] Pylint table1 isn't any warning\n")
+			fmt.Fprintf(os.Stderr, "[COUT] %s isn't any warning\n", userOrigFilePath(table1))
 		}
-		fmt.Fprintf(os.Stdout, "[COUT] End lint file：%s end\n", table1)
+		fmt.Fprintf(os.Stdout, "[COUT] End lint file：%s end\n", userOrigFilePath(table1))
 	}
 
 	return nil

--- a/component/images/python/pylint/src/pylint.conf
+++ b/component/images/python/pylint/src/pylint.conf
@@ -75,7 +75,7 @@ output-format=text
 files-output=no
 
 # Tells whether to display a full report or only the messages
-reports=no
+reports=yes
 
 # Python expression which should return a note less than 10 (10 is the highest
 # note). You have access to the variables errors warning, statement which
@@ -376,3 +376,4 @@ exclude-protected=_asdict,_fields,_replace,_source,_make
 # Exceptions that will emit a warning when being caught. Defaults to
 # "Exception"
 overgeneral-exceptions=Exception
+ 

--- a/component/images/python/pylint/src/pylint.conf
+++ b/component/images/python/pylint/src/pylint.conf
@@ -1,0 +1,378 @@
+[MASTER]
+
+# Specify a configuration file.
+#rcfile=
+
+# Python code to execute, usually for sys.path manipulation such as
+# pygtk.require().
+#init-hook=
+
+# Add files or directories to the blacklist. They should be base names, not
+# paths.
+ignore=CVS
+
+# Pickle collected data for later comparisons.
+persistent=yes
+
+# List of plugins (as comma separated values of python modules names) to load,
+# usually to register additional checkers.
+load-plugins=
+
+# Use multiple processes to speed up Pylint.
+jobs=1
+
+# Allow loading of arbitrary C extensions. Extensions are imported into the
+# active Python interpreter and may run arbitrary code.
+unsafe-load-any-extension=no
+
+# A comma-separated list of package or module names from where C extensions may
+# be loaded. Extensions are loading into the active Python interpreter and may
+# run arbitrary code
+extension-pkg-whitelist=
+
+# Allow optimization of some AST trees. This will activate a peephole AST
+# optimizer, which will apply various small optimizations. For instance, it can
+# be used to obtain the result of joining multiple strings with the addition
+# operator. Joining a lot of strings can lead to a maximum recursion error in
+# Pylint and this flag can prevent that. It has one side effect, the resulting
+# AST will be different than the one from reality.
+optimize-ast=no
+
+
+[MESSAGES CONTROL]
+
+# Only show warnings with the listed confidence levels. Leave empty to show
+# all. Valid levels: HIGH, INFERENCE, INFERENCE_FAILURE, UNDEFINED
+confidence=
+
+# Enable the message, report, category or checker with the given id(s). You can
+# either give multiple identifier separated by comma (,) or put this option
+# multiple time. See also the "--disable" option for examples.
+#enable=
+
+# Disable the message, report, category or checker with the given id(s). You
+# can either give multiple identifiers separated by comma (,) or put this
+# option multiple times (only on the command line, not in the configuration
+# file where it should appear only once).You can also use "--disable=all" to
+# disable everything first and then reenable specific checks. For example, if
+# you want to run only the similarities checker, you can use "--disable=all
+# --enable=similarities". If you want to run only the classes checker, but have
+# no Warning level messages displayed, use"--disable=all --enable=classes
+# --disable=W"
+disable=import-star-module-level,old-octal-literal,oct-method,print-statement,unpacking-in-except,parameter-unpacking,backtick,old-raise-syntax,old-ne-operator,long-suffix,dict-view-method,dict-iter-method,metaclass-assignment,next-method-called,raising-string,indexing-exception,raw_input-builtin,long-builtin,file-builtin,execfile-builtin,coerce-builtin,cmp-builtin,buffer-builtin,basestring-builtin,apply-builtin,filter-builtin-not-iterating,using-cmp-argument,useless-suppression,range-builtin-not-iterating,suppressed-message,no-absolute-import,old-division,cmp-method,reload-builtin,zip-builtin-not-iterating,intern-builtin,unichr-builtin,reduce-builtin,standarderror-builtin,unicode-builtin,xrange-builtin,coerce-method,delslice-method,getslice-method,setslice-method,input-builtin,round-builtin,hex-method,nonzero-method,map-builtin-not-iterating
+
+
+[REPORTS]
+
+# Set the output format. Available formats are text, parseable, colorized, msvs
+# (visual studio) and html. You can also give a reporter class, eg
+# mypackage.mymodule.MyReporterClass.
+output-format=text
+
+# Put messages in a separate file for each module / package specified on the
+# command line instead of printing them on stdout. Reports (if any) will be
+# written in a file name "pylint_global.[txt|html]".
+files-output=no
+
+# Tells whether to display a full report or only the messages
+reports=no
+
+# Python expression which should return a note less than 10 (10 is the highest
+# note). You have access to the variables errors warning, statement which
+# respectively contain the number of errors / warnings messages and the total
+# number of statements analyzed. This is used by the global evaluation report
+# (RP0004).
+evaluation=10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10)
+
+# Template used to display messages. This is a python new-style format string
+# used to format the message information. See doc for all details
+#msg-template=
+
+
+[VARIABLES]
+
+# Tells whether we should check for unused import in __init__ files.
+init-import=no
+
+# A regular expression matching the name of dummy variables (i.e. expectedly
+# not used).
+dummy-variables-rgx=_$|dummy
+
+# List of additional names supposed to be defined in builtins. Remember that
+# you should avoid to define new builtins when possible.
+additional-builtins=
+
+# List of strings which can identify a callback function by name. A callback
+# name must start or end with one of those strings.
+callbacks=cb_,_cb
+
+
+[SIMILARITIES]
+
+# Minimum lines number of a similarity.
+min-similarity-lines=4
+
+# Ignore comments when computing similarities.
+ignore-comments=yes
+
+# Ignore docstrings when computing similarities.
+ignore-docstrings=yes
+
+# Ignore imports when computing similarities.
+ignore-imports=no
+
+
+[TYPECHECK]
+
+# Tells whether missing members accessed in mixin class should be ignored. A
+# mixin class is detected if its name ends with "mixin" (case insensitive).
+ignore-mixin-members=yes
+
+# List of module names for which member attributes should not be checked
+# (useful for modules/projects where namespaces are manipulated during runtime
+# and thus existing member attributes cannot be deduced by static analysis. It
+# supports qualified module names, as well as Unix pattern matching.
+ignored-modules=
+
+# List of classes names for which member attributes should not be checked
+# (useful for classes with attributes dynamically set). This supports can work
+# with qualified names.
+ignored-classes=
+
+# List of members which are set dynamically and missed by pylint inference
+# system, and so shouldn't trigger E1101 when accessed. Python regular
+# expressions are accepted.
+generated-members=
+
+
+[LOGGING]
+
+# Logging modules to check that the string format arguments are in logging
+# function parameter format
+logging-modules=logging
+
+
+[FORMAT]
+
+# Maximum number of characters on a single line.
+max-line-length=100
+
+# Regexp for a line that is allowed to be longer than the limit.
+ignore-long-lines=^\s*(# )?<?https?://\S+>?$
+
+# Allow the body of an if to be on the same line as the test if there is no
+# else.
+single-line-if-stmt=no
+
+# List of optional constructs for which whitespace checking is disabled. `dict-
+# separator` is used to allow tabulation in dicts, etc.: {1  : 1,\n222: 2}.
+# `trailing-comma` allows a space between comma and closing bracket: (a, ).
+# `empty-line` allows space-only lines.
+no-space-check=trailing-comma,dict-separator
+
+# Maximum number of lines in a module
+max-module-lines=1000
+
+# String used as indentation unit. This is usually "    " (4 spaces) or "\t" (1
+# tab).
+indent-string='    '
+
+# Number of spaces of indent required inside a hanging  or continued line.
+indent-after-paren=4
+
+# Expected format of line ending, e.g. empty (any line ending), LF or CRLF.
+expected-line-ending-format=
+
+
+[BASIC]
+
+# List of builtins function names that should not be used, separated by a comma
+bad-functions=map,filter,input
+
+# Good variable names which should always be accepted, separated by a comma
+good-names=i,j,k,ex,Run,_
+
+# Bad variable names which should always be refused, separated by a comma
+bad-names=foo,bar,baz,toto,tutu,tata
+
+# Colon-delimited sets of names that determine each other's naming style when
+# the name regexes allow several styles.
+name-group=
+
+# Include a hint for the correct naming format with invalid-name
+include-naming-hint=no
+
+# Regular expression matching correct function names
+function-rgx=[a-z_][a-z0-9_]{2,30}$
+
+# Naming hint for function names
+function-name-hint=[a-z_][a-z0-9_]{2,30}$
+
+# Regular expression matching correct variable names
+variable-rgx=[a-z_][a-z0-9_]{2,30}$
+
+# Naming hint for variable names
+variable-name-hint=[a-z_][a-z0-9_]{2,30}$
+
+# Regular expression matching correct constant names
+const-rgx=(([A-Z_][A-Z0-9_]*)|(__.*__))$
+
+# Naming hint for constant names
+const-name-hint=(([A-Z_][A-Z0-9_]*)|(__.*__))$
+
+# Regular expression matching correct attribute names
+attr-rgx=[a-z_][a-z0-9_]{2,30}$
+
+# Naming hint for attribute names
+attr-name-hint=[a-z_][a-z0-9_]{2,30}$
+
+# Regular expression matching correct argument names
+argument-rgx=[a-z_][a-z0-9_]{2,30}$
+
+# Naming hint for argument names
+argument-name-hint=[a-z_][a-z0-9_]{2,30}$
+
+# Regular expression matching correct class attribute names
+class-attribute-rgx=([A-Za-z_][A-Za-z0-9_]{2,30}|(__.*__))$
+
+# Naming hint for class attribute names
+class-attribute-name-hint=([A-Za-z_][A-Za-z0-9_]{2,30}|(__.*__))$
+
+# Regular expression matching correct inline iteration names
+inlinevar-rgx=[A-Za-z_][A-Za-z0-9_]*$
+
+# Naming hint for inline iteration names
+inlinevar-name-hint=[A-Za-z_][A-Za-z0-9_]*$
+
+# Regular expression matching correct class names
+class-rgx=[A-Z_][a-zA-Z0-9]+$
+
+# Naming hint for class names
+class-name-hint=[A-Z_][a-zA-Z0-9]+$
+
+# Regular expression matching correct module names
+module-rgx=(([a-z_][a-z0-9_]*)|([A-Z][a-zA-Z0-9]+))$
+
+# Naming hint for module names
+module-name-hint=(([a-z_][a-z0-9_]*)|([A-Z][a-zA-Z0-9]+))$
+
+# Regular expression matching correct method names
+method-rgx=[a-z_][a-z0-9_]{2,30}$
+
+# Naming hint for method names
+method-name-hint=[a-z_][a-z0-9_]{2,30}$
+
+# Regular expression which should only match function or class names that do
+# not require a docstring.
+no-docstring-rgx=^_
+
+# Minimum line length for functions/classes that require docstrings, shorter
+# ones are exempt.
+docstring-min-length=-1
+
+
+[ELIF]
+
+# Maximum number of nested blocks for function / method body
+max-nested-blocks=5
+
+
+[SPELLING]
+
+# Spelling dictionary name. Available dictionaries: none. To make it working
+# install python-enchant package.
+spelling-dict=
+
+# List of comma separated words that should not be checked.
+spelling-ignore-words=
+
+# A path to a file that contains private dictionary; one word per line.
+spelling-private-dict-file=
+
+# Tells whether to store unknown words to indicated private dictionary in
+# --spelling-private-dict-file option instead of raising a message.
+spelling-store-unknown-words=no
+
+
+[MISCELLANEOUS]
+
+# List of note tags to take in consideration, separated by a comma.
+notes=FIXME,XXX,TODO
+
+
+[IMPORTS]
+
+# Deprecated modules which should not be used, separated by a comma
+deprecated-modules=regsub,TERMIOS,Bastion,rexec
+
+# Create a graph of every (i.e. internal and external) dependencies in the
+# given file (report RP0402 must not be disabled)
+import-graph=
+
+# Create a graph of external dependencies in the given file (report RP0402 must
+# not be disabled)
+ext-import-graph=
+
+# Create a graph of internal dependencies in the given file (report RP0402 must
+# not be disabled)
+int-import-graph=
+
+
+[DESIGN]
+
+# Maximum number of arguments for function / method
+max-args=5
+
+# Argument names that match this expression will be ignored. Default to name
+# with leading underscore
+ignored-argument-names=_.*
+
+# Maximum number of locals for function / method body
+max-locals=15
+
+# Maximum number of return / yield for function / method body
+max-returns=6
+
+# Maximum number of branch for function / method body
+max-branches=12
+
+# Maximum number of statements in function / method body
+max-statements=50
+
+# Maximum number of parents for a class (see R0901).
+max-parents=7
+
+# Maximum number of attributes for a class (see R0902).
+max-attributes=7
+
+# Minimum number of public methods for a class (see R0903).
+min-public-methods=2
+
+# Maximum number of public methods for a class (see R0904).
+max-public-methods=20
+
+# Maximum number of boolean expressions in a if statement
+max-bool-expr=5
+
+
+[CLASSES]
+
+# List of method names used to declare (i.e. assign) instance attributes.
+defining-attr-methods=__init__,__new__,setUp
+
+# List of valid names for the first argument in a class method.
+valid-classmethod-first-arg=cls
+
+# List of valid names for the first argument in a metaclass class method.
+valid-metaclass-classmethod-first-arg=mcs
+
+# List of member names, which should be excluded from the protected access
+# warning.
+exclude-protected=_asdict,_fields,_replace,_source,_make
+
+
+[EXCEPTIONS]
+
+# Exceptions that will emit a warning when being caught. Defaults to
+# "Exception"
+overgeneral-exceptions=Exception


### PR DESCRIPTION
## Build pylint component

```bash
docker build -t containerops/pylint .
(workdir:contianerops/component/images/python/pylint)
```

## Set pylint parameter
```bash
1.The default pylint prameter in contianerops/component/images/python/pylint/src/pylint.conf.   
You can modify it befor build the component.
2.You can modify the lint parameter via set the environment variable "CO_LINTPARA" by run the componet
```
```

## Run and test pylint component
```bash
docker run --env CO_CODERPO="coderepo=https://github.com/haijunTan/pyhello.git"  --env CO_LINTPARA="--reports=no" containerops/pylint:latest

Output result:
[COUT] CO_TEST = coderepo=https://github.com/haijunTan/pyhello.git
Cloning into '/var/opt/gopath/src/tmp'...
[COUT] Get input pylint prameter is "--reports=no",and other is default
------------------------------
[COUT] Start lint file：pylinttest/pylintnowarning.py
[COUT] End lint file：pylinttest/pylintnowarning.py end
------------------------------
[COUT] Start lint file：pylinttest/pylinttest.py
[COUT] pylinttest/pylintnowarning.py isn't any warning
************* Module pylinttest
W:  3, 0: Found indentation with tabs instead of spaces (mixed-indentation)
C:  3, 0: Unnecessary parens after 'print' keyword (superfluous-parens)
W:  6, 0: Found indentation with tabs instead of spaces (mixed-indentation)
W:  7, 0: Found indentation with tabs instead of spaces (mixed-indentation)
W: 10, 0: Found indentation with tabs instead of spaces (mixed-indentation)
C:  1, 0: Missing module docstring (missing-docstring)
C:  2, 0: Missing function docstring (missing-docstring)
C:  5, 0: Missing function docstring (missing-docstring)
C:  7, 1: Invalid variable name "x" (invalid-name)
W:  7, 1: Unused variable 'x' (unused-variable)
[COUT] End lint file：pylinttest/pylinttest.py end
------------------------------
[COUT] Start lint file：pylinttest/pylinttest1.py
************* Module pylinttest1
W:  3, 0: Found indentation with tabs instead of spaces (mixed-indentation)
C:  3, 0: Unnecessary parens after 'print' keyword (superfluous-parens)
W:  4, 0: Found indentation with tabs instead of spaces (mixed-indentation)
W:  7, 0: Found indentation with tabs instead of spaces (mixed-indentation)
C:  7, 0: Unnecessary parens after 'print' keyword (superfluous-parens)
W: 10, 0: Found indentation with tabs instead of spaces (mixed-indentation)
W: 11, 0: Found indentation with tabs instead of spaces (mixed-indentation)
W: 14, 0: Found indentation with tabs instead of spaces (mixed-indentation)
C:  1, 0: Missing module docstring (missing-docstring)
C:  2, 0: Missing function docstring (missing-docstring)
W:  4, 1: Unused variable 'unusevary' (unused-variable)
C:  6, 0: Missing function docstring (missing-docstring)
C:  9, 0: Missing function docstring (missing-docstring)
W: 10, 1: Unused variable 'unusevarx' (unused-variable)
[COUT] End lint file：pylinttest/pylinttest1.py end
[COUT] CO_RESULT = true```
