### PR TITLE
The singular demo for cncf

### DIFF
--- a/demo/cncf/singular/Dockerfile
+++ b/demo/cncf/singular/Dockerfile
@@ -1,0 +1,60 @@
+# Copyright 2016 - 2017 Huawei Technologies Co., Ltd. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM hub.opshub.sh/containerops/golang:1.8.3
+MAINTAINER Zhen Ju <juzhenatpku@gmail.com>
+
+USER root
+
+RUN apt-get update && apt-get install -y gcc make g++
+
+ENV PATH $PATH:$GOPATH/src/github.com/Huawei/containerops
+
+RUN mkdir -p $GOPATH/src/github.com/Huawei/
+
+WORKDIR $GOPATH/src/github.com/Huawei/
+RUN git clone https://github.com/Huawei/containerops
+
+# The essential dependencies for singular
+RUN go get "github.com/cloudflare/cfssl/cli"
+RUN go get "github.com/cloudflare/cfssl/cli/genkey"
+RUN go get "github.com/cloudflare/cfssl/cli/sign"
+RUN go get "github.com/cloudflare/cfssl/csr"
+RUN go get "github.com/cloudflare/cfssl/initca"
+RUN go get "github.com/cloudflare/cfssl/signer"
+RUN go get "github.com/digitalocean/godo"
+RUN go get "github.com/fernet/fernet-go"
+RUN go get "github.com/logrusorgru/aurora"
+RUN go get "github.com/mitchellh/go-homedir"
+RUN go get "github.com/pkg/sftp"
+RUN go get "github.com/spf13/cobra"
+RUN go get "github.com/spf13/viper"
+RUN go get "golang.org/x/crypto/ssh"
+RUN go get "golang.org/x/net/context"
+RUN go get "golang.org/x/oauth2"
+RUN go get "gopkg.in/yaml.v2"
+
+WORKDIR $GOPATH/src/github.com/Huawei/containerops/singular/
+RUN go build
+
+#ADD codes/*.go  $GOPATH/src/github.com/Huawei/containerops/demo/cncf/
+#ADD singular.template.yaml $GOPATH/src/github.com/Huawei/containerops/demo/cncf/
+
+WORKDIR $GOPATH/src/github.com/Huawei/containerops/demo/cncf/singular/codes/
+RUN go build -o ../singular-demo
+
+WORKDIR $GOPATH/src/github.com/Huawei/containerops/demo/cncf/singular/
+RUN cp $GOPATH/src/github.com/Huawei/containerops/singular/singular ./
+
+CMD ./singular-demo

--- a/demo/cncf/singular/README.md
+++ b/demo/cncf/singular/README.md
@@ -1,0 +1,63 @@
+## Deploy a kubernetes cluster with ContainerOps singular
+
+```bash
+docker build -t hub.opshub.sh/containerops/cncf-demo-singular .
+```
+
+
+```bash
+docker run --env CO_DATA="\
+	token=435a054fb1f81e439a63a608eddb67208a66cb11d6b7abeaa3d89aac777d4d1d \
+	kube_apiserver_url=https://hub.opshub.sh/binary/v1/containerops/singular/binary/kube-apiserver/1.6.7 \
+	kube_controllermanager_url=https://hub.opshub.sh/binary/v1/containerops/singular/binary/kube-controller-manager/1.6.7 \
+	kube_scheduler_url=https://hub.opshub.sh/binary/v1/containerops/singular/binary/kube-scheduler/1.6.7 \
+	kubectl_url=https://hub.opshub.sh/binary/v1/containerops/singular/binary/kubectl/1.6.7 \
+	kubelete_url=https://hub.opshub.sh/binary/v1/containerops/singular/binary/kubelet/1.6.7 \
+	kube_proxy_url=https://hub.opshub.sh/binary/v1/containerops/singular/binary/kube-proxy/1.6.7" \
+hub.opshub.sh/containerops/cncf-demo-singular:latest
+
+```
+
+```dockerfile
+FROM hub.opshub.sh/containerops/golang:1.8.3
+MAINTAINER Zhen Ju <juzhenatpku@gmail.com>
+
+USER root
+RUN apt-get update && apt-get install -y gcc make g++
+ENV PATH $PATH:$GOPATH/src/github.com/Huawei/containerops
+
+RUN mkdir -p $GOPATH/src/github.com/Huawei/
+
+WORKDIR $GOPATH/src/github.com/Huawei/
+RUN git clone https://github.com/Huawei/containerops
+
+# The essential dependencies for singular
+RUN go get "github.com/cloudflare/cfssl/cli"
+RUN go get "github.com/cloudflare/cfssl/cli/genkey"
+RUN go get "github.com/cloudflare/cfssl/cli/sign"
+RUN go get "github.com/cloudflare/cfssl/csr"
+RUN go get "github.com/cloudflare/cfssl/initca"
+RUN go get "github.com/cloudflare/cfssl/signer"
+RUN go get "github.com/digitalocean/godo"
+RUN go get "github.com/fernet/fernet-go"
+RUN go get "github.com/logrusorgru/aurora"
+RUN go get "github.com/mitchellh/go-homedir"
+RUN go get "github.com/pkg/sftp"
+RUN go get "github.com/spf13/cobra"
+RUN go get "github.com/spf13/viper"
+RUN go get "golang.org/x/crypto/ssh"
+RUN go get "golang.org/x/net/context"
+RUN go get "golang.org/x/oauth2"
+RUN go get "gopkg.in/yaml.v2"
+
+WORKDIR $GOPATH/src/github.com/Huawei/containerops/singular/
+RUN go build
+
+WORKDIR $GOPATH/src/github.com/Huawei/containerops/demo/cncf/singular/codes/
+RUN go build -o ../singular-demo
+
+WORKDIR $GOPATH/src/github.com/Huawei/containerops/demo/cncf/singular/
+RUN cp $GOPATH/src/github.com/Huawei/containerops/singular/singular ./
+
+CMD ./singular-demo
+```

--- a/demo/cncf/singular/README.md
+++ b/demo/cncf/singular/README.md
@@ -7,6 +7,7 @@ docker build -t hub.opshub.sh/containerops/cncf-demo-singular .
 
 ```bash
 docker run --env CO_DATA="\
+	action=release \
 	token=435a054fb1f81e439a63a608eddb67208a66cb11d6b7abeaa3d89aac777d4d1d \
 	kube_apiserver_url=https://hub.opshub.sh/binary/v1/containerops/singular/binary/kube-apiserver/1.6.7 \
 	kube_controllermanager_url=https://hub.opshub.sh/binary/v1/containerops/singular/binary/kube-controller-manager/1.6.7 \

--- a/demo/cncf/singular/codes/singular.go
+++ b/demo/cncf/singular/codes/singular.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"html/template"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func main() {
+	data := os.Getenv("CO_DATA")
+	if len(data) == 0 {
+		fmt.Fprintf(os.Stderr, "[COUT] %s\n", "The CO_DATA value is null.")
+		fmt.Fprintf(os.Stdout, "[COUT] CO_RESULT = %s\n", "The CO_DATA value is null.")
+		os.Exit(1)
+	}
+
+	token, kubeApiServerUrl, kubeControllerManagerUrl, kubeSchedulerUrl, kubectlUrl, kubeleteUrl, kubeProxyUrl, err := parseEnv(data)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "[COUT] Parse the CO_DATA error: %s\n", err.Error())
+		fmt.Fprintf(os.Stdout, "[COUT] CO_RESULT = %s\n", "false")
+		os.Exit(1)
+	}
+
+	bs, err := ioutil.ReadFile("./singular.template.yaml")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "COUT] Failed to read the template file: %s", err.Error())
+		os.Exit(1)
+	}
+	singularTemplate := string(bs)
+
+	singular := map[string]interface{}{
+		"Token":                    token,
+		"KubeApiServerUrl":         kubeApiServerUrl,
+		"KubeControllerManagerUrl": kubeControllerManagerUrl,
+		"KubeSchedulerUrl":         kubeSchedulerUrl,
+		"KubectlUrl":               kubectlUrl,
+		"KubeletUrl":               kubeleteUrl,
+		"KubeProxyUrl":             kubeProxyUrl,
+	}
+	t := template.Must(template.New("Singular").Parse(singularTemplate))
+	var buf bytes.Buffer
+	err = t.Execute(&buf, singular)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to generate yaml from template: %s", err.Error())
+		os.Exit(1)
+	}
+
+	// Write the yaml to file
+	if err := ioutil.WriteFile("./singular.yaml", buf.Bytes(), os.ModePerm); err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to write yaml into file: %s", err.Error())
+		os.Exit(1)
+	}
+
+	// Call singular binary to deploy the k8s cluster
+	// Since the Provider and Token is provied in the yaml, the config file is not necessary here, create a mock
+	mockConfigContent := `
+	[singular]
+	provider="digitalocean"
+	token="helloworld"
+	`
+	if err := ioutil.WriteFile("./runtime.toml", []byte(mockConfigContent), os.ModePerm); err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to generate mock config: %s", err.Error())
+		os.Exit(1)
+	}
+	cmd := exec.Command("./singular", "deploy", "template", "./singular.yaml", "--config", "./runtime.toml", "--verbose", "true")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to deploy k8s cluster with singular: %s", err.Error())
+		os.Exit(1)
+	}
+	fmt.Fprintf(os.Stdout, "[COUT] CO_RESULT=true")
+}
+
+// Parse CO_DATA value, and return token, and the urls of kubernetes components
+func parseEnv(env string) (token, kubeApiServerUrl, kubeControllerManagerUrl, kubeSchedulerUrl, kubectlUrl, kubeleteUrl, kubeProxyUrl string, err error) {
+	files := strings.Fields(env)
+	if len(files) == 0 {
+		err = fmt.Errorf("CO_DATA value is null\n")
+		return
+	}
+
+	for _, v := range files {
+		s := strings.Split(v, "=")
+		key, value := s[0], s[1]
+
+		switch key {
+		case "token":
+			token = value
+		case "kube_apiserver_url":
+			kubeApiServerUrl = value
+		case "kube_controllermanager_url":
+			kubeControllerManagerUrl = value
+		case "kube_scheduler_url":
+			kubeSchedulerUrl = value
+		case "kubectl_url":
+			kubectlUrl = value
+		case "kubelete_url":
+			kubeleteUrl = value
+		case "kube_proxy_url":
+			kubeProxyUrl = value
+		default:
+			fmt.Fprintf(os.Stdout, "[COUT] Unknown Parameter: [%s]\n", s)
+		}
+	}
+	return
+}

--- a/demo/cncf/singular/codes/singular.go
+++ b/demo/cncf/singular/codes/singular.go
@@ -14,20 +14,27 @@ func main() {
 	data := os.Getenv("CO_DATA")
 	if len(data) == 0 {
 		fmt.Fprintf(os.Stderr, "[COUT] %s\n", "The CO_DATA value is null.")
-		fmt.Fprintf(os.Stdout, "[COUT] CO_RESULT = %s\n", "The CO_DATA value is null.")
+		fmt.Fprintf(os.Stdout, "[COUT] CO_RESULT = %s\n", "false")
 		os.Exit(1)
 	}
 
-	token, kubeApiServerUrl, kubeControllerManagerUrl, kubeSchedulerUrl, kubectlUrl, kubeleteUrl, kubeProxyUrl, err := parseEnv(data)
+	action, token, kubeApiServerUrl, kubeControllerManagerUrl, kubeSchedulerUrl, kubectlUrl, kubeleteUrl, kubeProxyUrl, err := parseEnv(data)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "[COUT] Parse the CO_DATA error: %s\n", err.Error())
-		fmt.Fprintf(os.Stdout, "[COUT] CO_RESULT = %s\n", "false")
+		fmt.Fprintf(os.Stdout, "[COUT] CO_RESULT = false\n")
+		os.Exit(1)
+	}
+
+	if action != "release" {
+		fmt.Fprintf(os.Stderr, "[COUT] %s\n", "Unknown action, the component only support build, test and release action.")
+		fmt.Fprintf(os.Stdout, "[COUT] CO_RESULT = false\n")
 		os.Exit(1)
 	}
 
 	bs, err := ioutil.ReadFile("./singular.template.yaml")
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "COUT] Failed to read the template file: %s", err.Error())
+		fmt.Fprintf(os.Stderr, "[COUT] Failed to read the template file: %s\n", err.Error())
+		fmt.Fprintf(os.Stdout, "[COUT] CO_RESULT = false\n")
 		os.Exit(1)
 	}
 	singularTemplate := string(bs)
@@ -45,13 +52,15 @@ func main() {
 	var buf bytes.Buffer
 	err = t.Execute(&buf, singular)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Failed to generate yaml from template: %s", err.Error())
+		fmt.Fprintf(os.Stderr, "Failed to generate yaml from template: %s\n", err.Error())
+		fmt.Fprintf(os.Stdout, "[COUT] CO_RESULT = false\n")
 		os.Exit(1)
 	}
 
 	// Write the yaml to file
 	if err := ioutil.WriteFile("./singular.yaml", buf.Bytes(), os.ModePerm); err != nil {
-		fmt.Fprintf(os.Stderr, "Failed to write yaml into file: %s", err.Error())
+		fmt.Fprintf(os.Stderr, "[COUT] Failed to write yaml into file: %s\n", err.Error())
+		fmt.Fprintf(os.Stdout, "[COUT] CO_RESULT = false\n")
 		os.Exit(1)
 	}
 
@@ -63,21 +72,23 @@ func main() {
 	token="helloworld"
 	`
 	if err := ioutil.WriteFile("./runtime.toml", []byte(mockConfigContent), os.ModePerm); err != nil {
-		fmt.Fprintf(os.Stderr, "Failed to generate mock config: %s", err.Error())
+		fmt.Fprintf(os.Stderr, "[COUT] Failed to generate mock config: %s\n", err.Error())
+		fmt.Fprintf(os.Stdout, "[COUT] CO_RESULT = false\n")
 		os.Exit(1)
 	}
 	cmd := exec.Command("./singular", "deploy", "template", "./singular.yaml", "--config", "./runtime.toml", "--verbose", "true")
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	if err := cmd.Run(); err != nil {
-		fmt.Fprintf(os.Stderr, "Failed to deploy k8s cluster with singular: %s", err.Error())
+		fmt.Fprintf(os.Stderr, "Failed to deploy k8s cluster with singular: %s\n", err.Error())
+		fmt.Fprintf(os.Stdout, "[COUT] CO_RESULT = false\n")
 		os.Exit(1)
 	}
-	fmt.Fprintf(os.Stdout, "[COUT] CO_RESULT=true")
+	fmt.Fprintf(os.Stdout, "[COUT] CO_RESULT = true\n")
 }
 
 // Parse CO_DATA value, and return token, and the urls of kubernetes components
-func parseEnv(env string) (token, kubeApiServerUrl, kubeControllerManagerUrl, kubeSchedulerUrl, kubectlUrl, kubeleteUrl, kubeProxyUrl string, err error) {
+func parseEnv(env string) (action, token, kubeApiServerUrl, kubeControllerManagerUrl, kubeSchedulerUrl, kubectlUrl, kubeleteUrl, kubeProxyUrl string, err error) {
 	files := strings.Fields(env)
 	if len(files) == 0 {
 		err = fmt.Errorf("CO_DATA value is null\n")
@@ -89,6 +100,8 @@ func parseEnv(env string) (token, kubeApiServerUrl, kubeControllerManagerUrl, ku
 		key, value := s[0], s[1]
 
 		switch key {
+		case "action":
+			action = value
 		case "token":
 			token = value
 		case "kube_apiserver_url":

--- a/demo/cncf/singular/singular.template.yaml
+++ b/demo/cncf/singular/singular.template.yaml
@@ -1,0 +1,137 @@
+uri: containerops/demo-for-cncf-ci/deploy-cncf-stack
+title: Demo For Deploy Cloud Native Computing Foundation CI Working Group
+version: 4
+tag: latest
+nodes: 3
+service:
+  provider: digitalocean
+  token: {{.Token}}
+  region: sfo2
+  size: 4gb
+  image: ubuntu-17-04-x64
+infra:
+infras:
+  -
+    name: etcd
+    version: etcd-3.2.2
+    nodes:
+      master: 3
+      node: 0
+    components:
+      -   
+        binary: etcd
+        url: https://hub.opshub.sh/binary/v1/containerops/singular/binary/etcd/3.2.2
+        package: false
+        systemd: etcd-3.2.2
+        ca: etcd-3.2.2
+      - 
+        binary: etcdctl
+        url: https://hub.opshub.sh/binary/v1/containerops/singular/binary/etcdctl/3.2.2
+        package: false    
+  -
+    name: flannel
+    version: flannel-0.7.1
+    nodes:
+      master: 3
+      node: 0
+    dependencies:
+      - etcd
+    components:
+      -
+        binary: flanneld
+        url: https://hub.opshub.sh/binary/v1/containerops/singular/binary/flanneld/0.7.1
+        package: false
+        systemd: flannel-0.7.1
+        ca: flannel-0.7.1
+        before: "etcdctl --endpoints={{.Nodes}} --ca-file=/etc/kubernetes/ssl/ca.pem --cert-file=/etc/flanneld/ssl/flanneld.pem --key-file=/etc/flanneld/ssl/flanneld-key.pem set /kubernetes/network/config '{\"Network\":\"'172.30.0.0/16'\", \"SubnetLen\": 24, \"Backend\": {\"Type\": \"vxlan\"}}'"
+      - 
+        binary: mk-docker-opts.sh
+        url: https://hub.opshub.sh/binary/v1/containerops/singular/binary/mk-docker-opts.sh/0.7.1
+        package: false
+  -
+    name: docker
+    version: docker-17.04.0-ce
+    nodes:
+      master: 3
+      node: 0
+    dependencies:
+      - flannel      
+    components:
+      -
+        binary: docker
+        url: https://hub.opshub.sh/binary/v1/containerops/singular/binary/docker/17.04.0-ce
+        package: false
+        systemd: docker-17.04.0-ce
+        before: "iptables -F && iptables -X && iptables -F -t nat && iptables -X -t nat"
+        after: "iptables -P FORWARD ACCEPT"
+      - 
+        binary: dockerd
+        url: https://hub.opshub.sh/binary/v1/containerops/singular/binary/dockerd/17.04.0-ce
+        package: false
+      -
+        binary: docker-init
+        url: https://hub.opshub.sh/binary/v1/containerops/singular/binary/docker-init/17.04.0-ce
+        package: false
+      -
+        binary: docker-proxy
+        url: https://hub.opshub.sh/binary/v1/containerops/singular/binary/docker-proxy/17.04.0-ce
+        package: false
+      -
+        binary: docker-runc
+        url: https://hub.opshub.sh/binary/v1/containerops/singular/binary/docker-runc/17.04.0-ce
+        package: false
+      -
+        binary: docker-containerd
+        url: https://hub.opshub.sh/binary/v1/containerops/singular/binary/docker-containerd/17.04.0-ce
+        package: false
+      -
+        binary: docker-containerd-ctr
+        url: https://hub.opshub.sh/binary/v1/containerops/singular/binary/docker-containerd-ctr/17.04.0-ce
+        package: false
+      -
+        binary: docker-containerd-shim
+        url: https://hub.opshub.sh/binary/v1/containerops/singular/binary/docker-containerd-shim/17.04.0-ce
+        package: false
+  -   
+    name: kubernetes
+    version: kubernetes-1.6.7
+    nodes:
+      master: 1
+      node: 3
+    dependencies:
+      - etcd
+      - flannel
+      - docker
+    components:
+      -
+        binary: kube-apiserver
+        url: {{.KubeApiServerUrl}}
+        package: false
+        systemd: kube-apiserver-1.6.7
+        ca: kubernetes-1.6.7
+      - 
+        binary: kube-controller-manager
+        url: {{.KubeControllerManagerUrl}}
+        package: false
+        systemd: kube-controller-manager-1.6.7
+        ca: kubernetes-1.6.7
+      - 
+        binary: kube-scheduler
+        url: {{.KubeSchedulerUrl}}
+        package: false
+        systemd: kube-scheduler-1.6.7
+      -
+        binary: kubectl
+        url: {{.KubectlUrl}}
+        package: false
+      -
+        bianry: kubelet
+        url: {{.KubeletUrl}}
+        package: false
+        systemd: kubelet-1.6.7
+      -
+        binary: kube-proxy
+        url: {{.KubeProxyUrl}}
+        package: false
+        systemd: kube-proxy-1.6.7
+        ca: kube-proxy-1.6.7


### PR DESCRIPTION
The component does this:
Receive the input data from `CO_DATA` env var, including:
- action
- token
- kube_apiserver_url
- kube_controllermanager_url
- kube_scheduler_url
- kubectl_url
- kubelete_url
- kube_proxy_url

Then clone the ContainerOps repo from github, compile the singular binary, the demo binary, then run the demo. The demo will parse the `CO_DATA` to generate the yaml that singular needs, then call singular to deploy the kubernetes cluster.