### PR TITLE
unittest: fixed unittest compact with python2

### DIFF
--- a/component/python/test/unittest/README.md
+++ b/component/python/test/unittest/README.md
@@ -11,13 +11,13 @@ docker build -t containerops/unittest .
 
 ### Component Usage
 ```bash
-docker run --rm -e CO_DATA='git-url=https://github.com/minhhh/regex.git entry-path=.' containerops/unittest
-docker run --rm -e CO_DATA='git-url=https://github.com/minhhh/regex.git entry-path=. version=python' containerops/unittest
+docker run --rm -e CO_DATA='git-url=https://github.com/minhhh/regex.git entry-module=test.test_regex' containerops/unittest
+docker run --rm -e CO_DATA='git-url=https://github.com/minhhh/regex.git entry-module=test.test_regex version=python' containerops/unittest
 ```
 
 ### Parameters
 - `git-url` is the source git repo url
 - `version` is one of `python`, `python2`, `python3`, `py3k`.  default is `py3k`
-- `entry-path` is the entry file or path for unittest
+- `entry-module` is the unittest module name you want to test
 
 ### Versions 1.0.0

--- a/component/python/test/unittest/bootstrap.py
+++ b/component/python/test/unittest/bootstrap.py
@@ -70,8 +70,10 @@ def pip_install(file_name, version='py3k'):
     return True
 
 
-def unittest(file_name, version='py3k'):
-    r = subprocess.run('cd {}/{};{} /root/xmlrunner'.format(REPO_PATH, file_name, get_python_cmd(version)), shell=True)
+def unittest(module, version='py3k'):
+    os.system('cp /root/xmlrunner {}'.format(REPO_PATH))
+    r = subprocess.run('cd {};{} xmlrunner {}'.format(REPO_PATH,
+        get_python_cmd(version), module), shell=True)
 
     if r.returncode != 0:
         return False
@@ -95,7 +97,7 @@ def parse_argument():
     if not data:
         return {}
 
-    validate = ['git-url', 'entry-path', 'version']
+    validate = ['git-url', 'entry-module', 'version']
     ret = {}
     for s in data.split(' '):
         s = s.strip()
@@ -131,8 +133,8 @@ def main():
 
     init_env(version)
 
-    entry_path = argv.get('entry-path')
-    if not entry_path:
+    entry_module = argv.get('entry-module')
+    if not entry_module:
         print("[COUT] The entry-path value is null", file=sys.stderr)
         print("[COUT] CO_RESULT = false")
         return
@@ -159,7 +161,7 @@ def main():
         pip_install(file_name, version)
 
 
-    out = unittest(entry_path, version)
+    out = unittest(entry_module, version)
     echo_xml()
 
     if not out:


### PR DESCRIPTION
on python2 we must use the test module name,
it is not compact with directory.