### PR TITLE
Pilotage web hook

### DIFF
--- a/demo/containerops/pilotage-hook/Dockerfile-co-build
+++ b/demo/containerops/pilotage-hook/Dockerfile-co-build
@@ -1,0 +1,7 @@
+FROM daocloud.io/golang
+
+ADD ./codes /
+WORKDIR /
+RUN go build -o /usr/local/bin/cobuild co_build.go
+RUN mkdir -p $GOPATH/src/github.com/Huawei/
+CMD cobuild

--- a/demo/containerops/pilotage-hook/Dockerfile-co-changed
+++ b/demo/containerops/pilotage-hook/Dockerfile-co-changed
@@ -1,6 +1,24 @@
-FROM daocloud.io/golang
-ADD ./codes /
+# Copyright 2016 - 2017 Huawei Technologies Co., Ltd. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM hub.opshub.sh/containerops/golang:1.8.3
+MAINTAINER Zhen Ju<juzhen@huawei.com>
+
+ADD ./codes/co_changed.go /
+ADD ./codes/common.go /
+
 WORKDIR /
-RUN go build -o /usr/local/bin/is_co_changed code_changed.go
+RUN go build -o /usr/local/bin/cochanged common.go co_changed.go
 RUN mkdir -p $GOPATH/src/github.com/Huawei/
-CMD is_co_changed
+CMD cochanged

--- a/demo/containerops/pilotage-hook/Dockerfile-co-changed
+++ b/demo/containerops/pilotage-hook/Dockerfile-co-changed
@@ -1,0 +1,6 @@
+FROM daocloud.io/golang
+ADD ./codes /
+WORKDIR /
+RUN go build -o /usr/local/bin/is_co_changed code_changed.go
+RUN mkdir -p $GOPATH/src/github.com/Huawei/
+CMD is_co_changed

--- a/demo/containerops/pilotage-hook/Dockerfile-co-redeploy
+++ b/demo/containerops/pilotage-hook/Dockerfile-co-redeploy
@@ -15,11 +15,11 @@
 FROM hub.opshub.sh/containerops/golang:1.8.3
 MAINTAINER Zhen Ju<juzhen@huawei.com>
 
-
-ADD ./codes/co_build.go /
+ADD ./codes/co_redeploy.go /
 ADD ./codes/common.go /
 
+RUN go get -v golang.org/x/crypto/ssh
 WORKDIR /
-RUN go build -o /usr/local/bin/cobuild common.go co_build.go
+RUN go build -o /usr/local/bin/coredeploy common.go co_redeploy.go
 RUN mkdir -p $GOPATH/src/github.com/Huawei/
-CMD cobuild
+CMD coredeploy

--- a/demo/containerops/pilotage-hook/codes/co_build.go
+++ b/demo/containerops/pilotage-hook/codes/co_build.go
@@ -1,0 +1,196 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func main() {
+	data := os.Getenv("CO_DATA")
+	if len(data) == 0 {
+		fmt.Fprintf(os.Stderr, "[COUT] %s\n", "The CO_DATA value is null.")
+		fmt.Fprintf(os.Stdout, "[COUT] CO_RESULT = %s\n", "false")
+		os.Exit(1)
+	}
+
+	target, hub, namespace, repo, tag, binary, err := parseEnv(data)
+
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "[COUT] Parse the CO_DATA: %s\n", err.Error())
+		fmt.Fprintf(os.Stdout, "[COUT] CO_RESULT = false\n")
+		os.Exit(1)
+	}
+
+	if err := clone(); err != nil {
+		fmt.Fprintf(os.Stderr, "[COUT] Failed to clone git repo: %s\n", err.Error())
+		fmt.Fprintf(os.Stdout, "[COUT] CO_RESULT = false\n")
+		os.Exit(1)
+		return
+	}
+
+	localFile, err := build(target)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "[COUT] Failed to build project: %s\n", err.Error())
+		fmt.Fprintf(os.Stdout, "[COUT] CO_RESULT = false\n")
+		os.Exit(1)
+		return
+	}
+
+	// push
+	url, err := push(localFile, hub, namespace, repo, tag, binary)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "[COUT] Failed to upload binary: %s\n", err.Error())
+		fmt.Fprintf(os.Stdout, "[COUT] CO_RESULT = false\n")
+		os.Exit(1)
+		return
+	}
+
+	fmt.Fprintf(os.Stdout, "[COUT] CO_RESULT=true")
+	fmt.Fprintf(os.Stdout, "[COUT] CO_URL=%s\n", url)
+}
+
+func getGitRepoParentPath() (string, error) {
+	gopath := os.Getenv("GOPATH")
+	if gopath == "" {
+		return "", fmt.Errorf("Failed to get $GOPATH")
+	}
+	repoParentPath := fmt.Sprintf("%s/src/github.com/Huawei", gopath)
+	return repoParentPath, nil
+}
+
+func clone() error {
+	repoParentPath, err := getGitRepoParentPath()
+	if err != nil {
+		return err
+	}
+
+	cmd := exec.Command("git", "clone", "https://github.com/Huawei/containerops")
+	cmd.Dir = repoParentPath
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	return cmd.Run()
+}
+
+func parseEnv(env string) (target, hub, namespace, repo, tag, binary string, err error) {
+	files := strings.Fields(env)
+	if len(files) == 0 {
+		err = fmt.Errorf("CO_DATA value is null\n")
+		return
+	}
+
+	for _, v := range files {
+		s := strings.Split(v, "=")
+		key, value := s[0], s[1]
+
+		switch key {
+		case "target":
+			target = value
+		case "hub":
+			hub = value
+		case "namespace":
+			namespace = value
+		case "repo":
+			repo = value
+		case "tag":
+			tag = value
+		case "binary":
+			binary = value
+		default:
+			fmt.Fprintf(os.Stdout, "[COUT] Unknown Parameter: [%s]\n", s)
+		}
+	}
+	return
+}
+
+func build(target string) (string, error) {
+	if err := installDependencies(); err != nil {
+		return "", err
+	}
+
+	repoParentPath, err := getGitRepoParentPath()
+	if err != nil {
+		return "", err
+	}
+
+	buildCmd := exec.Command("go", "build")
+	buildCmd.Stderr = os.Stderr
+	buildCmd.Stdout = os.Stdout
+	buildCmd.Dir = fmt.Sprintf("%s/containerops/%s", repoParentPath, target)
+	// var buf bytes.Buffer
+	// buildCmd.Stdout = buf
+	// buildCmd.Stderr = buf
+	if err := buildCmd.Run(); err != nil {
+		return "", err
+	}
+
+	localFile := fmt.Sprintf("%s/%s", buildCmd.Dir, target)
+	return localFile, nil
+}
+
+func installDependencies() error {
+	deps := [][]string{
+		{"get", "-v", "github.com/Sirupsen/logrus"},
+		{"get", "-v", "github.com/cloudflare/cfssl/cli"},
+		{"get", "-v", "github.com/cloudflare/cfssl/cli/genkey"},
+		{"get", "-v", "github.com/cloudflare/cfssl/cli/sign"},
+		{"get", "-v", "github.com/cloudflare/cfssl/csr"},
+		{"get", "-v", "github.com/cloudflare/cfssl/initca"},
+		{"get", "-v", "github.com/cloudflare/cfssl/signer"},
+		{"get", "-v", "github.com/digitalocean/godo"},
+		{"get", "-v", "github.com/fernet/fernet-go"},
+		{"get", "-v", "github.com/jinzhu/gorm"},
+		{"get", "-v", "github.com/jinzhu/gorm/dialects/mysql"},
+		{"get", "-v", "github.com/logrusorgru/aurora"},
+		{"get", "-v", "github.com/mitchellh/go-homedir"},
+		{"get", "-v", "github.com/pkg/sftp"},
+		{"get", "-v", "github.com/spf13/cobra"},
+		{"get", "-v", "github.com/spf13/viper"},
+		{"get", "-v", "golang.org/x/crypto/ssh"},
+		{"get", "-v", "golang.org/x/net/context"},
+		{"get", "-v", "golang.org/x/oauth2"},
+		{"get", "-v", "gopkg.in/macaron.v1"},
+		{"get", "-v", "gopkg.in/yaml.v2"},
+	}
+	for i := 0; i < len(deps); i++ {
+		args := deps[i]
+		cmd := exec.Command("go", args...)
+		cmd.Stderr = os.Stderr
+		cmd.Stdout = os.Stdout
+		if err := cmd.Run(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func push(filePath, hub, namespace, repo, tag, binary string) (string, error) {
+	url := fmt.Sprintf("https://%s/binary/v1/%s/%s/binary/%s/%s", hub, namespace, repo, tag, binary)
+	file, err := os.Open(filePath)
+	if err != nil {
+		return "", err
+	}
+	defer file.Close()
+
+	client := http.Client{}
+	req, _ := http.NewRequest(http.MethodPut, url, file)
+	res, err := client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer res.Body.Close()
+	// res, err := http.Post(url, "binary/octet-stream", file)
+	// if err != nil {
+	//     return err
+	// }
+	// defer res.Body.Close()
+
+	if res.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("Failed to upload binary file, status: %d", res.StatusCode)
+	}
+
+	return url, nil
+}

--- a/demo/containerops/pilotage-hook/codes/co_build.go
+++ b/demo/containerops/pilotage-hook/codes/co_build.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"net/http"
 	"os"
-	"os/exec"
 	"strings"
 )
 
@@ -52,29 +51,6 @@ func main() {
 	fmt.Fprintf(os.Stdout, "[COUT] CO_URL=%s\n", url)
 }
 
-func getGitRepoParentPath() (string, error) {
-	gopath := os.Getenv("GOPATH")
-	if gopath == "" {
-		return "", fmt.Errorf("Failed to get $GOPATH")
-	}
-	repoParentPath := fmt.Sprintf("%s/src/github.com/Huawei", gopath)
-	return repoParentPath, nil
-}
-
-func clone() error {
-	repoParentPath, err := getGitRepoParentPath()
-	if err != nil {
-		return err
-	}
-
-	cmd := exec.Command("git", "clone", "https://github.com/Huawei/containerops")
-	cmd.Dir = repoParentPath
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-
-	return cmd.Run()
-}
-
 func parseEnv(env string) (target, hub, namespace, repo, tag, binary string, err error) {
 	files := strings.Fields(env)
 	if len(files) == 0 {
@@ -104,67 +80,6 @@ func parseEnv(env string) (target, hub, namespace, repo, tag, binary string, err
 		}
 	}
 	return
-}
-
-func build(target string) (string, error) {
-	if err := installDependencies(); err != nil {
-		return "", err
-	}
-
-	repoParentPath, err := getGitRepoParentPath()
-	if err != nil {
-		return "", err
-	}
-
-	buildCmd := exec.Command("go", "build")
-	buildCmd.Stderr = os.Stderr
-	buildCmd.Stdout = os.Stdout
-	buildCmd.Dir = fmt.Sprintf("%s/containerops/%s", repoParentPath, target)
-	// var buf bytes.Buffer
-	// buildCmd.Stdout = buf
-	// buildCmd.Stderr = buf
-	if err := buildCmd.Run(); err != nil {
-		return "", err
-	}
-
-	localFile := fmt.Sprintf("%s/%s", buildCmd.Dir, target)
-	return localFile, nil
-}
-
-func installDependencies() error {
-	deps := [][]string{
-		{"get", "-v", "github.com/Sirupsen/logrus"},
-		{"get", "-v", "github.com/cloudflare/cfssl/cli"},
-		{"get", "-v", "github.com/cloudflare/cfssl/cli/genkey"},
-		{"get", "-v", "github.com/cloudflare/cfssl/cli/sign"},
-		{"get", "-v", "github.com/cloudflare/cfssl/csr"},
-		{"get", "-v", "github.com/cloudflare/cfssl/initca"},
-		{"get", "-v", "github.com/cloudflare/cfssl/signer"},
-		{"get", "-v", "github.com/digitalocean/godo"},
-		{"get", "-v", "github.com/fernet/fernet-go"},
-		{"get", "-v", "github.com/jinzhu/gorm"},
-		{"get", "-v", "github.com/jinzhu/gorm/dialects/mysql"},
-		{"get", "-v", "github.com/logrusorgru/aurora"},
-		{"get", "-v", "github.com/mitchellh/go-homedir"},
-		{"get", "-v", "github.com/pkg/sftp"},
-		{"get", "-v", "github.com/spf13/cobra"},
-		{"get", "-v", "github.com/spf13/viper"},
-		{"get", "-v", "golang.org/x/crypto/ssh"},
-		{"get", "-v", "golang.org/x/net/context"},
-		{"get", "-v", "golang.org/x/oauth2"},
-		{"get", "-v", "gopkg.in/macaron.v1"},
-		{"get", "-v", "gopkg.in/yaml.v2"},
-	}
-	for i := 0; i < len(deps); i++ {
-		args := deps[i]
-		cmd := exec.Command("go", args...)
-		cmd.Stderr = os.Stderr
-		cmd.Stdout = os.Stdout
-		if err := cmd.Run(); err != nil {
-			return err
-		}
-	}
-	return nil
 }
 
 func push(filePath, hub, namespace, repo, tag, binary string) (string, error) {

--- a/demo/containerops/pilotage-hook/codes/co_build.go
+++ b/demo/containerops/pilotage-hook/codes/co_build.go
@@ -48,7 +48,7 @@ func main() {
 		return
 	}
 
-	fmt.Fprintf(os.Stdout, "[COUT] CO_RESULT=true")
+	fmt.Fprintf(os.Stdout, "[COUT] CO_RESULT=true\n")
 	fmt.Fprintf(os.Stdout, "[COUT] CO_URL=%s\n", url)
 }
 

--- a/demo/containerops/pilotage-hook/codes/co_changed.go
+++ b/demo/containerops/pilotage-hook/codes/co_changed.go
@@ -32,7 +32,7 @@ func main() {
 
 	changed, err := diff(target)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "[COUT] Parse the CO_DATA error: %s\n", err.Error())
+		fmt.Fprintf(os.Stderr, "[COUT] Failed to compare merges: %s\n", err.Error())
 		fmt.Fprintf(os.Stdout, "[COUT] CO_RESULT = false\n")
 		os.Exit(1)
 		return
@@ -104,6 +104,7 @@ func diff(target string) (bool, error) {
 	prevMergeCommit := parts[0]
 
 	diffCmd := exec.Command("git", "diff", fmt.Sprintf("%s..%s", prevMergeCommit, lastMergeCommit), "--name-only")
+	diffCmd.Dir = fmt.Sprintf("%s/containerops/%s/", repoParentPath, target)
 	buf.Reset()
 	diffCmd.Stdout = &buf
 	diffCmd.Stderr = &buf

--- a/demo/containerops/pilotage-hook/codes/co_changed.go
+++ b/demo/containerops/pilotage-hook/codes/co_changed.go
@@ -42,29 +42,6 @@ func main() {
 	fmt.Fprintf(os.Stdout, fmt.Sprintf("[COUT] CO_CHANGED=%t", changed))
 }
 
-func getGitRepoParentPath() (string, error) {
-	gopath := os.Getenv("GOPATH")
-	if gopath == "" {
-		return "", fmt.Errorf("Failed to get $GOPATH")
-	}
-	repoParentPath := fmt.Sprintf("%s/src/github.com/Huawei", gopath)
-	return repoParentPath, nil
-}
-
-func clone() error {
-	repoParentPath, err := getGitRepoParentPath()
-	if err != nil {
-		return err
-	}
-
-	cmd := exec.Command("git", "clone", "https://github.com/Huawei/containerops")
-	cmd.Dir = repoParentPath
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-
-	return cmd.Run()
-}
-
 func diff(target string) (bool, error) {
 	repoParentPath, err := getGitRepoParentPath()
 	if err != nil {

--- a/demo/containerops/pilotage-hook/codes/co_changed.go
+++ b/demo/containerops/pilotage-hook/codes/co_changed.go
@@ -38,8 +38,8 @@ func main() {
 		return
 	}
 
-	fmt.Fprintf(os.Stdout, "[COUT] CO_RESULT=true")
-	fmt.Fprintf(os.Stdout, fmt.Sprintf("[COUT] CO_CHANGED=%t", changed))
+	fmt.Fprintf(os.Stdout, "[COUT] CO_RESULT=true\n")
+	fmt.Fprintf(os.Stdout, fmt.Sprintf("[COUT] CO_CHANGED=%t\n", changed))
 }
 
 func diff(target string) (bool, error) {

--- a/demo/containerops/pilotage-hook/codes/co_redeploy.go
+++ b/demo/containerops/pilotage-hook/codes/co_redeploy.go
@@ -1,0 +1,76 @@
+/*
+Copyright 2016 - 2017 Huawei Technologies Co., Ltd. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	common "github.com/Huawei/containerops/common/utils"
+)
+
+func main() {
+
+	data := os.Getenv("CO_DATA")
+	if len(data) == 0 {
+		fmt.Fprintf(os.Stderr, "[COUT] %s\n", "The CO_DATA value is null.")
+		fmt.Fprintf(os.Stdout, "[COUT] CO_RESULT = %s\n", "false")
+		os.Exit(1)
+	}
+
+	target, url, key, err := parseEnv(data)
+
+	err = update(target, url, key)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "[COUT] Failed to update service %s: %s\n", target, err.Error())
+		fmt.Fprintf(os.Stdout, "[COUT] CO_RESULT = false\n")
+		os.Exit(1)
+	}
+
+	fmt.Fprintf(os.Stdout, "[COUT] CO_RESULT=true\n")
+}
+
+func parseEnv(env string) (target, url, sshKey string, err error) {
+	files := strings.Fields(env)
+	if len(files) == 0 {
+		err = fmt.Errorf("CO_DATA value is null\n")
+		return
+	}
+
+	for _, v := range files {
+		s := strings.Split(v, "=")
+		key, value := s[0], s[1]
+
+		switch key {
+		case "target":
+			target = value
+		case "url":
+			url = value
+		case "key":
+			sshKey = value
+		default:
+			fmt.Fprintf(os.Stdout, "[COUT] Unknown Parameter: [%s]\n", s)
+		}
+	}
+	return
+}
+
+func update(target, url, key string) error {
+	cmd := fmt.Sprintf("/var/containerops/scripts/%s/deploy.sh '%s'", target, url)
+	return common.SSHCommand("root", key, "hub.opshub.sh", 22, cmd, os.Stdout, os.Stderr)
+}

--- a/demo/containerops/pilotage-hook/codes/code_changed.go
+++ b/demo/containerops/pilotage-hook/codes/code_changed.go
@@ -1,0 +1,147 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func main() {
+	data := os.Getenv("CO_DATA")
+	if len(data) == 0 {
+		fmt.Fprintf(os.Stderr, "[COUT] %s\n", "The CO_DATA value is null.")
+		fmt.Fprintf(os.Stdout, "[COUT] CO_RESULT = %s\n", "false")
+		os.Exit(1)
+	}
+
+	target, err := parseEnv(data)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "[COUT] Parse the CO_DATA: %s\n", err.Error())
+		fmt.Fprintf(os.Stdout, "[COUT] CO_RESULT = false\n")
+		os.Exit(1)
+	}
+
+	if err := clone(); err != nil {
+		fmt.Fprintf(os.Stderr, "[COUT] Failed to clone git repo: %s\n", err.Error())
+		fmt.Fprintf(os.Stdout, "[COUT] CO_RESULT = false\n")
+		os.Exit(1)
+		return
+	}
+
+	changed, err := diff(target)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "[COUT] Parse the CO_DATA error: %s\n", err.Error())
+		fmt.Fprintf(os.Stdout, "[COUT] CO_RESULT = false\n")
+		os.Exit(1)
+		return
+	}
+
+	fmt.Fprintf(os.Stdout, "[COUT] CO_RESULT=true")
+	fmt.Fprintf(os.Stdout, fmt.Sprintf("[COUT] CO_CHANGED=%t", changed))
+}
+
+func getGitRepoParentPath() (string, error) {
+	gopath := os.Getenv("GOPATH")
+	if gopath == "" {
+		return "", fmt.Errorf("Failed to get $GOPATH")
+	}
+	repoParentPath := fmt.Sprintf("%s/src/github.com/Huawei", gopath)
+	return repoParentPath, nil
+}
+
+func clone() error {
+	repoParentPath, err := getGitRepoParentPath()
+	if err != nil {
+		return err
+	}
+
+	cmd := exec.Command("git", "clone", "https://github.com/Huawei/containerops")
+	cmd.Dir = repoParentPath
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	return cmd.Run()
+}
+
+func diff(target string) (bool, error) {
+	repoParentPath, err := getGitRepoParentPath()
+	if err != nil {
+		return false, err
+	}
+
+	logCmd := exec.Command("git", "log", "--merges", "--oneline") //, "|", "head", "n2")
+	logCmd.Dir = fmt.Sprintf("%s/containerops", repoParentPath)
+
+	if err != nil {
+		return false, err
+	}
+
+	headCmd := exec.Command("head", "-n2")
+
+	headCmd.Stdin, err = logCmd.StdoutPipe()
+	if err != nil {
+		return false, err
+	}
+	var buf bytes.Buffer
+	headCmd.Stdout = &buf
+	headCmd.Start()
+	logCmd.Run()
+	headCmd.Wait()
+	results := strings.Split(buf.String(), "\n")
+	if len(results) < 2 {
+		return false, fmt.Errorf("No comparisons")
+	}
+
+	lastMerge := results[0]
+	prevMerge := results[1]
+
+	parts := strings.Split(lastMerge, " ")
+	lastMergeCommit := parts[0]
+
+	parts = strings.Split(prevMerge, " ")
+	prevMergeCommit := parts[0]
+
+	diffCmd := exec.Command("git", "diff", fmt.Sprintf("%s..%s", prevMergeCommit, lastMergeCommit), "--name-only")
+	buf.Reset()
+	diffCmd.Stdout = &buf
+	diffCmd.Stderr = &buf
+	if err := diffCmd.Run(); err != nil {
+		return false, err
+	}
+
+	results = strings.Split(buf.String(), "\n")
+	// TODO Test the senarios that folders or files are renamed
+	singularCodeChanged := false
+	targetFolder := fmt.Sprintf("%s/", target)
+	for i := 0; i < len(results); i++ {
+		changedFile := results[i]
+		if strings.HasPrefix(changedFile, targetFolder) /* && strings.HasSuffix(changedFile, ".go")  */ {
+			singularCodeChanged = true
+		}
+	}
+
+	return singularCodeChanged, nil
+}
+
+func parseEnv(env string) (target string, err error) {
+	files := strings.Fields(env)
+	if len(files) == 0 {
+		err = fmt.Errorf("CO_DATA value is null\n")
+		return
+	}
+
+	for _, v := range files {
+		s := strings.Split(v, "=")
+		key, value := s[0], s[1]
+
+		switch key {
+		case "target":
+			target = value
+		default:
+			fmt.Fprintf(os.Stdout, "[COUT] Unknown Parameter: [%s]\n", s)
+		}
+	}
+	return
+}

--- a/demo/containerops/pilotage-hook/codes/common.go
+++ b/demo/containerops/pilotage-hook/codes/common.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+)
+
+func clone() error {
+	repoParentPath, err := getGitRepoParentPath()
+	if err != nil {
+		return err
+	}
+
+	cmd := exec.Command("git", "clone", "https://github.com/Huawei/containerops")
+	cmd.Dir = repoParentPath
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	return cmd.Run()
+}
+
+func build(target string) (string, error) {
+	if err := installDependencies(); err != nil {
+		return "", err
+	}
+
+	repoParentPath, err := getGitRepoParentPath()
+	if err != nil {
+		return "", err
+	}
+
+	buildCmd := exec.Command("go", "build")
+	buildCmd.Stderr = os.Stderr
+	buildCmd.Stdout = os.Stdout
+	buildCmd.Dir = fmt.Sprintf("%s/containerops/%s", repoParentPath, target)
+	// var buf bytes.Buffer
+	// buildCmd.Stdout = buf
+	// buildCmd.Stderr = buf
+	if err := buildCmd.Run(); err != nil {
+		return "", err
+	}
+
+	localFile := fmt.Sprintf("%s/%s", buildCmd.Dir, target)
+	return localFile, nil
+}
+
+func installDependencies() error {
+	deps := [][]string{
+		{"get", "-v", "github.com/Sirupsen/logrus"},
+		{"get", "-v", "github.com/cloudflare/cfssl/cli"},
+		{"get", "-v", "github.com/cloudflare/cfssl/cli/genkey"},
+		{"get", "-v", "github.com/cloudflare/cfssl/cli/sign"},
+		{"get", "-v", "github.com/cloudflare/cfssl/csr"},
+		{"get", "-v", "github.com/cloudflare/cfssl/initca"},
+		{"get", "-v", "github.com/cloudflare/cfssl/signer"},
+		{"get", "-v", "github.com/digitalocean/godo"},
+		{"get", "-v", "github.com/fernet/fernet-go"},
+		{"get", "-v", "github.com/jinzhu/gorm"},
+		{"get", "-v", "github.com/jinzhu/gorm/dialects/mysql"},
+		{"get", "-v", "github.com/logrusorgru/aurora"},
+		{"get", "-v", "github.com/mitchellh/go-homedir"},
+		{"get", "-v", "github.com/pkg/sftp"},
+		{"get", "-v", "github.com/spf13/cobra"},
+		{"get", "-v", "github.com/spf13/viper"},
+		{"get", "-v", "golang.org/x/crypto/ssh"},
+		{"get", "-v", "golang.org/x/net/context"},
+		{"get", "-v", "golang.org/x/oauth2"},
+		{"get", "-v", "gopkg.in/macaron.v1"},
+		{"get", "-v", "gopkg.in/yaml.v2"},
+	}
+	for i := 0; i < len(deps); i++ {
+		args := deps[i]
+		cmd := exec.Command("go", args...)
+		cmd.Stderr = os.Stderr
+		cmd.Stdout = os.Stdout
+		if err := cmd.Run(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func getGitRepoParentPath() (string, error) {
+	gopath := os.Getenv("GOPATH")
+	if gopath == "" {
+		return "", fmt.Errorf("Failed to get $GOPATH")
+	}
+	repoParentPath := fmt.Sprintf("%s/src/github.com/Huawei", gopath)
+	return repoParentPath, nil
+}

--- a/pilotage/cmd/root.go
+++ b/pilotage/cmd/root.go
@@ -25,6 +25,7 @@ import (
 	"github.com/spf13/viper"
 
 	"github.com/Huawei/containerops/common"
+	"github.com/Huawei/containerops/pilotage/config"
 )
 
 var cfgFile string
@@ -68,6 +69,11 @@ func Execute() {
 // initConfig reads in config file and ENV variables if set.
 func initConfig() {
 	if err := common.SetConfig(cfgFile); err != nil {
+		fmt.Println(Red(err))
+		os.Exit(1)
+	}
+
+	if err := config.InitConfig(cfgFile); err != nil {
 		fmt.Println(Red(err))
 		os.Exit(1)
 	}

--- a/pilotage/config/config.go
+++ b/pilotage/config/config.go
@@ -1,0 +1,33 @@
+package config
+
+import (
+	"encoding/json"
+
+	"github.com/spf13/viper"
+)
+
+type WebHookConfig struct {
+	Host         string `json:"host"`
+	Namespace    string `json:"namespace"`
+	Repository   string `json:"repository"`
+	Binary       string `json:"binary"`
+	Tag          string `json:"tag"`
+	FlowFilePath string `json:"flowFilePath"`
+}
+
+var WebHook WebHookConfig
+
+func InitConfig(cfgFile string) error {
+	viper.SetConfigFile(cfgFile)
+	if err := viper.ReadInConfig(); err != nil {
+		return err
+	}
+
+	hookMap := viper.GetStringMap("hook")
+	bs, err := json.Marshal(hookMap)
+	if err != nil {
+		return err
+	}
+
+	return json.Unmarshal(bs, &WebHook)
+}

--- a/pilotage/handler/webhook.go
+++ b/pilotage/handler/webhook.go
@@ -14,29 +14,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package router
+package handler
 
-import (
-	"gopkg.in/macaron.v1"
+import macaron "gopkg.in/macaron.v1"
 
-	"github.com/Huawei/containerops/pilotage/handler"
-)
-
-// SetRunDaemonRouters is
-func SetRunDaemonRouters(m *macaron.Macaron) {
-	m.Group("/flow", func() {
-		m.Group("/v1", func() {
-			m.Get("/:namespace/:repository/:flow/:tag/:number/runtime/:type", handler.GetFlowRuntime)
-		})
-	})
-	m.Post("/hook", handler.WebHook)
-}
-
-// SetStartDaemonRouters is
-func SetStartDaemonRouters(m *macaron.Macaron) {
-	m.Group("/flow", func() {
-		m.Group("/v1", func() {
-			m.Post("/:namespace/:repository/:flow/:tag/:type", handler.PostFlowRuntime)
-		})
-	})
+func WebHook(ctx *macaron.Context) (int, []byte) {
+	// TODO Run the flow:
+	// 1. Check if the singular changes
+	// 2. (if changed) Build new singular and push the binary to dockyard
+	// 3. ssh into the target server, update the singular service.
 }

--- a/pilotage/handler/webhook.go
+++ b/pilotage/handler/webhook.go
@@ -16,11 +16,45 @@ limitations under the License.
 
 package handler
 
-import macaron "gopkg.in/macaron.v1"
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"os"
+
+	"github.com/Huawei/containerops/pilotage/config"
+	log "github.com/Sirupsen/logrus"
+	macaron "gopkg.in/macaron.v1"
+)
 
 func WebHook(ctx *macaron.Context) (int, []byte) {
 	// TODO Run the flow:
 	// 1. Check if the singular changes
 	// 2. (if changed) Build new singular and push the binary to dockyard
 	// 3. ssh into the target server, update the singular service.
+	url := fmt.Sprintf("%s/flow/v1/%s/%s/%s/%s/%s", config.WebHook.Host, config.WebHook.Namespace, config.WebHook.Repository, config.WebHook.Binary, config.WebHook.Tag, "yaml")
+
+	file, err := os.Open(config.WebHook.FlowFilePath)
+	if err != nil {
+		log.Error(err)
+		return http.StatusInternalServerError, []byte("Failed to read flow yaml file")
+	}
+	defer file.Close()
+
+	client := http.Client{}
+	req, _ := http.NewRequest(http.MethodPost, url, file)
+	res, err := client.Do(req)
+	if err != nil {
+		log.Error(err)
+		return http.StatusInternalServerError, []byte("Failed to request flow creation")
+	}
+	defer res.Body.Close()
+
+	bs, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		log.Error(err)
+		return http.StatusInternalServerError, []byte("Failed to get response from pilotage flow creation API")
+	}
+
+	return res.StatusCode, bs
 }

--- a/pilotage/router/router.go
+++ b/pilotage/router/router.go
@@ -29,7 +29,6 @@ func SetRunDaemonRouters(m *macaron.Macaron) {
 			m.Get("/:namespace/:repository/:flow/:tag/:number/runtime/:type", handler.GetFlowRuntime)
 		})
 	})
-	m.Post("/hook", handler.WebHook)
 }
 
 // SetStartDaemonRouters is
@@ -39,4 +38,5 @@ func SetStartDaemonRouters(m *macaron.Macaron) {
 			m.Post("/:namespace/:repository/:flow/:tag/:type", handler.PostFlowRuntime)
 		})
 	})
+	m.Post("/hook", handler.WebHook)
 }


### PR DESCRIPTION
Add the pilotage web hook API. When called, the hook will:
- Check if there is a code change of project singular
- Rebuild the project, push the binary to dockyard
- Update the singular service in opshub.sh

Other changes:
- Handling the hook config of pilotage
- A hook flow yaml file should be specified, the flow related code, Dockerfiles and yamls are put under containerops/demo/containerops/pilotage-hook/