### PR TITLE
Update pilotage hook API, ask for ns, reop, flow name and tag in URI.

### DIFF
--- a/pilotage/handler/run.go
+++ b/pilotage/handler/run.go
@@ -24,8 +24,9 @@ import (
 	"gopkg.in/macaron.v1"
 	"gopkg.in/yaml.v2"
 
-	"github.com/Huawei/containerops/pilotage/module"
 	"time"
+
+	"github.com/Huawei/containerops/pilotage/module"
 )
 
 // GetFlowRuntime is return flow runtime status and logs.
@@ -94,7 +95,7 @@ func PostFlowRuntime(ctx *macaron.Context) (int, []byte) {
 	switch ctx.Params("type") {
 	case "json":
 		if err := json.Unmarshal(data, &f); err != nil {
-			f.Log(fmt.Sprintf("Unmarshal the flow file error: %s", err.Error()), true	, true)
+			f.Log(fmt.Sprintf("Unmarshal the flow file error: %s", err.Error()), true, true)
 		}
 	case "yaml":
 		if err := yaml.Unmarshal(data, &f); err != nil {
@@ -110,7 +111,7 @@ func PostFlowRuntime(ctx *macaron.Context) (int, []byte) {
 		f.LocalRun(true, true)
 	}()
 	// Sleep one second to wait the init status change of flow
-	time.Sleep(1*time.Second)
+	time.Sleep(1 * time.Second)
 	resp := PostFlowResponse{Namespace: namespace, Repository: repository, Name: flowName, Tag: f.Tag,
 		Version: f.Version, Title: f.Title, Status: f.Status}
 	result, _ := json.Marshal(resp)

--- a/pilotage/handler/webhook.go
+++ b/pilotage/handler/webhook.go
@@ -28,11 +28,17 @@ import (
 )
 
 func WebHook(ctx *macaron.Context) (int, []byte) {
-	// TODO Run the flow:
+	// Run the flow:
 	// 1. Check if the singular changes
 	// 2. (if changed) Build new singular and push the binary to dockyard
 	// 3. ssh into the target server, update the singular service.
-	url := fmt.Sprintf("%s/flow/v1/%s/%s/%s/%s/%s", config.WebHook.Host, config.WebHook.Namespace, config.WebHook.Repository, config.WebHook.Binary, config.WebHook.Tag, "yaml")
+	namespace := ctx.Params("namespace")
+	repository := ctx.Params("repository")
+	flowName := ctx.Params("flow")
+	tag := ctx.Params("tag")
+	// TODO Parameter validation
+
+	url := fmt.Sprintf("%s/flow/v1/%s/%s/%s/%s/%s", config.WebHook.Host, namespace, repository, flowName, tag, "yaml")
 
 	file, err := os.Open(config.WebHook.FlowFilePath)
 	if err != nil {

--- a/pilotage/router/router.go
+++ b/pilotage/router/router.go
@@ -38,5 +38,5 @@ func SetStartDaemonRouters(m *macaron.Macaron) {
 			m.Post("/:namespace/:repository/:flow/:tag/:type", handler.PostFlowRuntime)
 		})
 	})
-	m.Post("/hook", handler.WebHook)
+	m.Post("/hook/:namespace/:repository/:flow/:tag", handler.WebHook)
 }


### PR DESCRIPTION
Update the pilotage web hook URL to `https://DOMAIN/hook/:namespace/:repository/:flowname/:tag`