### PR TITLE
Support tar file in assembling build service

### DIFF
--- a/assembling/cmd/daemon.go
+++ b/assembling/cmd/daemon.go
@@ -84,8 +84,6 @@ func startDaemon(cmd *cobra.Command, args []string) {
 	address := common.Assembling.Address
 	port := common.Assembling.Port
 
-	common.Assembling.Mode = "unix"
-
 	go func() {
 		switch common.Assembling.Mode {
 		case "https":

--- a/assembling/docs/api.md
+++ b/assembling/docs/api.md
@@ -1,0 +1,51 @@
+# API spec of assembling
+
+
+### POST  /assembling/build
+
+Receive the Dockerfile or archive file to build the image in an isolated environment.
+
+#### Request
+
+- **Syntax**
+```http
+HTTP/1.1
+POST  /assembling/build
+```
+
+- **Parameters**
+
+|Parameter|type|From|
+--|--|--
+|registry|string|Query|
+|namespace|string|Query|
+|image|string|Query|
+|tag|string|Query|
+|Dockerfile & archive file|binary|Body|
+
+> The body should be a single Dockerfile or, if some extra files are included, an archive file, which can be in the format of tar, gzip, bzip2 or xz, according to the [Docker Engine API](https://docs.docker.com/engine/api/v1.31/#operation/ImageBuild), section `REQUEST BODY`.
+
+
+
+- **Example**
+
+```http
+POST /assembling/build?registry=hub.opshub.sh&namespace=containerops&image=ubuntu&tag=14.04
+
+Body(Binary file)
+
+```
+
+#### Response On Success
+
+- **Syntax:**
+```
+HTTP/1.1 200 OK
+Content-Type: application/json
+```
+
+```json
+{
+  "endpoint" : "hub.opshub.sh/containerops/ubuntu:14.04"
+}
+```

--- a/pilotage/handler/webhook.go
+++ b/pilotage/handler/webhook.go
@@ -54,7 +54,7 @@ func WebHook(ctx *macaron.Context) (int, []byte) {
 		return http.StatusInternalServerError, []byte("Failed to validate flow URI")
 	}
 	if ns != namespace || repo != repository || name != flowName {
-		log.Error(err)
+		log.Error("Parameters in yaml not equal to those in URL")
 		return http.StatusInternalServerError, []byte("Invalid flow URI")
 	}
 


### PR DESCRIPTION
When calling build service, besides a Dockerfile, user can also upload an archive file to include some extra files or process for the image.