### PR TITLE
Feature/auto redeploy singular

### DIFF
--- a/demo/containerops/pilotage-hook/codes/co_build.go
+++ b/demo/containerops/pilotage-hook/codes/co_build.go
@@ -8,6 +8,12 @@ import (
 )
 
 func main() {
+	codeChanged := os.Getenv("CO_CODE_CHANGED")
+	if codeChanged == "false" {
+		fmt.Fprintf(os.Stdout, "[COUT] CO_RESULT=true\n")
+		os.Exit(0)
+	}
+
 	data := os.Getenv("CO_DATA")
 	if len(data) == 0 {
 		fmt.Fprintf(os.Stderr, "[COUT] %s\n", "The CO_DATA value is null.")
@@ -27,7 +33,6 @@ func main() {
 		fmt.Fprintf(os.Stderr, "[COUT] Failed to clone git repo: %s\n", err.Error())
 		fmt.Fprintf(os.Stdout, "[COUT] CO_RESULT = false\n")
 		os.Exit(1)
-		return
 	}
 
 	localFile, err := build(target)
@@ -35,7 +40,6 @@ func main() {
 		fmt.Fprintf(os.Stderr, "[COUT] Failed to build project: %s\n", err.Error())
 		fmt.Fprintf(os.Stdout, "[COUT] CO_RESULT = false\n")
 		os.Exit(1)
-		return
 	}
 
 	// push
@@ -44,7 +48,6 @@ func main() {
 		fmt.Fprintf(os.Stderr, "[COUT] Failed to upload binary: %s\n", err.Error())
 		fmt.Fprintf(os.Stdout, "[COUT] CO_RESULT = false\n")
 		os.Exit(1)
-		return
 	}
 
 	fmt.Fprintf(os.Stdout, "[COUT] CO_RESULT=true\n")

--- a/demo/containerops/pilotage-hook/codes/co_build.go
+++ b/demo/containerops/pilotage-hook/codes/co_build.go
@@ -21,7 +21,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	target, hub, namespace, repo, tag, binary, err := parseEnv(data)
+	target, hub, namespace, repo, binary, err := parseEnv(data)
 
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "[COUT] Parse the CO_DATA: %s\n", err.Error())
@@ -43,6 +43,13 @@ func main() {
 	}
 
 	// push
+	tag, err := lastCommitHash(target)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "[COUT] Failed to get last commit hash of project %s: %s\n", target, err.Error())
+		fmt.Fprintf(os.Stdout, "[COUT] CO_RESULT = false\n")
+		os.Exit(1)
+	}
+
 	url, err := push(localFile, hub, namespace, repo, tag, binary)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "[COUT] Failed to upload binary: %s\n", err.Error())
@@ -54,7 +61,7 @@ func main() {
 	fmt.Fprintf(os.Stdout, "[COUT] CO_URL=%s\n", url)
 }
 
-func parseEnv(env string) (target, hub, namespace, repo, tag, binary string, err error) {
+func parseEnv(env string) (target, hub, namespace, repo, binary string, err error) {
 	files := strings.Fields(env)
 	if len(files) == 0 {
 		err = fmt.Errorf("CO_DATA value is null\n")
@@ -74,8 +81,6 @@ func parseEnv(env string) (target, hub, namespace, repo, tag, binary string, err
 			namespace = value
 		case "repo":
 			repo = value
-		case "tag":
-			tag = value
 		case "binary":
 			binary = value
 		default:

--- a/demo/containerops/pilotage-hook/codes/co_changed.go
+++ b/demo/containerops/pilotage-hook/codes/co_changed.go
@@ -39,7 +39,7 @@ func main() {
 	}
 
 	fmt.Fprintf(os.Stdout, "[COUT] CO_RESULT=true\n")
-	fmt.Fprintf(os.Stdout, fmt.Sprintf("[COUT] CO_CHANGED=%t\n", changed))
+	fmt.Fprintf(os.Stdout, fmt.Sprintf("[COUT] CO_CODE_CHANGED=%t\n", changed))
 }
 
 func diff(target string) (bool, error) {

--- a/demo/containerops/pilotage-hook/codes/co_redeploy.go
+++ b/demo/containerops/pilotage-hook/codes/co_redeploy.go
@@ -27,6 +27,11 @@ import (
 )
 
 func main() {
+	codeChanged := os.Getenv("CO_CODE_CHANGED")
+	if codeChanged == "false" {
+		fmt.Fprintf(os.Stdout, "[COUT] CO_RESULT=true\n")
+		os.Exit(0)
+	}
 
 	data := os.Getenv("CO_DATA")
 	if len(data) == 0 {

--- a/demo/containerops/pilotage-hook/codes/co_redeploy.go
+++ b/demo/containerops/pilotage-hook/codes/co_redeploy.go
@@ -33,6 +33,13 @@ func main() {
 		os.Exit(0)
 	}
 
+	url := os.Getenv("CO_URL")
+	if url == "" {
+		fmt.Fprintf(os.Stderr, "[COUT] %s\n", "The CO_URL value is null.")
+		fmt.Fprintf(os.Stdout, "[COUT] CO_RESULT = false\n")
+		os.Exit(1)
+	}
+
 	data := os.Getenv("CO_DATA")
 	if len(data) == 0 {
 		fmt.Fprintf(os.Stderr, "[COUT] %s\n", "The CO_DATA value is null.")
@@ -40,7 +47,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	target, url, key, err := parseEnv(data)
+	target, key, err := parseEnv(data)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "[COUT] Parse the CO_DATA: %s\n", err.Error())
 		fmt.Fprintf(os.Stdout, "[COUT] CO_RESULT = false\n")
@@ -58,7 +65,7 @@ func main() {
 	fmt.Fprintf(os.Stdout, "[COUT] CO_RESULT=true\n")
 }
 
-func parseEnv(env string) (target, url, sshKey string, err error) {
+func parseEnv(env string) (target, sshKey string, err error) {
 	// Extract variable 'key'
 	index := strings.Index(env, "key=")
 	sshKey = env[index+4:]
@@ -78,8 +85,6 @@ func parseEnv(env string) (target, url, sshKey string, err error) {
 		switch key {
 		case "target":
 			target = value
-		case "url":
-			url = value
 		// case "key":
 		//     sshKey = value
 		default:

--- a/demo/containerops/pilotage-hook/codes/common.go
+++ b/demo/containerops/pilotage-hook/codes/common.go
@@ -1,9 +1,11 @@
 package main
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 	"os/exec"
+	"strings"
 )
 
 func clone() error {
@@ -43,6 +45,25 @@ func build(target string) (string, error) {
 
 	localFile := fmt.Sprintf("%s/%s", buildCmd.Dir, target)
 	return localFile, nil
+}
+
+func lastCommitHash(target string) (string, error) {
+	repoParentPath, err := getGitRepoParentPath()
+	if err != nil {
+		return "", err
+	}
+
+	buildCmd := exec.Command("git", "rev-parse", "HEAD")
+	buildCmd.Dir = fmt.Sprintf("%s/containerops/%s", repoParentPath, target)
+	var buf bytes.Buffer
+	buildCmd.Stdout = &buf
+	buildCmd.Stderr = &buf
+	if err := buildCmd.Run(); err != nil {
+		return "", err
+	}
+	commit := strings.Trim(buf.String(), "\n")
+
+	return commit, nil
 }
 
 func installDependencies() error {

--- a/demo/containerops/pilotage-hook/cohook-flow.yml
+++ b/demo/containerops/pilotage-hook/cohook-flow.yml
@@ -1,0 +1,97 @@
+# Copyright 2016 - 2017 Huawei Technologies Co., Ltd. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+uri: containerops/singular/cd-singular-daemon
+title: Demo For ContainerOps Pilotage Web Hook(Singular Auto Upgrade)
+version: 1
+tag: latest
+timeout: 0
+stages:
+  -
+    type: start
+    name: start
+    title: Start
+  -
+    type: normal
+    name: detect-singular-code-change
+    title: Detect if there is any changes on singular's code in the last merge.
+    sequencing: sequence
+    actions:
+      -
+        name: detect-singular-code-change
+        title: Tell code changes from the last git merge.
+        jobs:
+          -
+            name: detect-singular-code-change
+            type: component
+            kubectl: prometheus/prometheus-build.yaml
+            endpoint: hub.opshub.sh/containerops/cohook-code-changed:demov3
+            resources:
+              cpu: 2
+              memory: 4G
+            timeout: 0
+            environments:
+              - CO_DATA: "target=singular"
+            outputs: ["CO_CODE_CHANGED"]
+  -
+    type: normal
+    name: build-upload-singular
+    title: Build singular and upload the new version to opshub
+    sequencing: sequence
+    actions:
+      -
+        name: build-upload-singular
+        title: Build and upload singular
+        jobs:
+          -
+            name: build-upload-singular
+            type: component
+            kubectl: coredns/coredns-build.yaml #What's the meaning of kubelct?
+            endpoint: hub.opshub.sh/containerops/cohook-code-build:demov3
+            resources:
+              cpu: 2
+              memory: 4G
+            timeout: 0
+            environments:
+              - CO_DATA: "target=singular hub=hub.opshub.sh namespace=containerops repo=cohook-demo binary=singular"
+            subscriptions:
+                - detect-singular-code-change.detect-singular-code-change.detect-singular-code-change[CO_CODE_CHANGED]: CO_CODE_CHANGED
+            outputs: ["CO_URL"]
+  -
+    type: normal
+    name: redeploy-singular
+    title: Redeploy the singular service.
+    sequencing: sequence
+    actions:
+      -
+        name: redeploy-singular
+        title: Deploy the newly built singular
+        jobs:
+          -
+            type: component
+            kubectl: kubernetes/kubernetes-build.yaml
+            endpoint: hub.opshub.sh/containerops/cohook-code-redeploy:demov3
+            resources:
+              cpu: 2
+              memory: 8G
+            timeout: 0
+            environments:
+                - CO_DATA: "target=singular key=-----BEGIN RSA PRIVATE KEY-----\nMIIEpAIBAAKCAQEAub6NXNGA9iyTBshZhJ6qntUB4BRWgEilV20XklOFitsqV2iu\nvtDf9+05xhGM64june0+c5eEPFvbFuvXyPqZd+YC0vsFG/Xrqa2Fm4ORvHFfpNn4\n2O/ADq4iO+9VqbMmm0ykkXd8s8VfT4bljT/+cVgT48ctJrvKmgsQnMbZdf6lLE0B\n7pQCcUpY0c1NWPWX7ltJ7Tqq8/ivJgIMmzLUzEF9sVQp0mU6LYOgWovdlmtGRuG9\n5lZETv+4QWSFBdXj8j8lJq5ux6FE9cS8OyCmqUQ0oahKaINvFuFYo8xEGq8GPn/U\nyXXu7j3jh/A4ttLi0hPeVI2NTYKe6Iwx8DV6pQIDAQABAoIBAGLu3uawZEs65Lj5\nH80moeRlulD7JDPB/ec6IRL8T6XtJHlYNbNHF/Q7M8mO8YtG7SnLAreY3YM0vdZQ\nmiffarzVE24C6+6/pt1ComZ5xrcjf/kTbJtH3/kxwORBj1QLKyYOxZ0BkrdCCokW\nZdA9ZK5EZputLBx0a+5utFN9CrjwlokWjsipxFeJjlNrVKYkcJapbBdChjMxKELD\nFjVrgSB1cEazC5JirzL01J1+cjbwNb3EfTJ97pdGs1mjaES/Qyb3ALVdkPzysTrU\n/BbSc66tyWOgW9/JJgmwkPE5fMPexKbvJcyJyjgqkL441S30gqSPXv0bBWNAlCsI\n8yL6WUUCgYEA9EDPvJpV4R5NFgChb5f4hmvlu/zoq9mEwA5I3SfGF8bA9V2pwSIz\nCqbWACS+FX1+OOGpDpj1IY4jCVqPyEfsl9u8JqxXkBWSTSa4dhO+pX+hKINz6bEk\nIh+LaaVD/mslkCp4nSApNV4lPpiALlUbpBM3KN6LOiye91B87eI7++sCgYEAwq1k\nwyVJsCtOl/KbyVNp+/ZVLXrfbMgv9DKTvUSFIkHVN7Dj5XoBQfziPc+BLNiN6eSM\nd08d2Qhi3VnvtEjtKbDdTfVnxYtUxuGfcQGpSP0YcEPUJc90yjaoizwHudXaHT8W\nE94TmLcZThNecaKsXV7xkcOV7Y3Ahdbm4KN0j68CgYEAnyfcNTkb3KSx9jRS/TQ5\nbN3BxMz3j4MdTUgBkpnoKnYIJdnyUzbFq5sqts06TyaGqOniDvD8SfEkQ2QPbKHx\nOMKlx01lgS2NN1iTud0DzTNs/8koLo6OzO1hGmXl+FI5F8eU8E2UjIHcIv2cCJTM\nfg1HVAovDqkkrGJ2BUv1aiECgYATOyG7DVHsLzsCU5sEFlNf6oObjInJqzThgKWL\nittD+RDhAX5hyt2Y8SxAQuFV1saeFk+x8YTXTbbGev3s509WUPxrmRR5NTxYsS0Y\n8rsQVMA3RtwMKCQ3XZLkvjddKjzzqqm5qLRy35OGXO91dkZkqt5eMd37q4cbMZF5\nG2yGTQKBgQCoLe2KZg+tGvfbvlmzwydCt2F39E04DrtJP5u9E8qKekjadQAq0eaw\n/YygmQ9kbZcj/nYR06ciEwnYIREd8EOXAK3NUeJMeglIvwgNBDVL+JyNeI3f46LP\nFXwckiEOPmjcp5c8UTFKTmjJxzhcadubXUEz7LRzCU45WuSQz783bg==\n-----END RSA PRIVATE KEY-----"
+            subscriptions:
+                - detect-singular-code-change.detect-singular-code-change.detect-singular-code-change[CO_CODE_CHANGED]: CO_CODE_CHANGED
+                - build-upload-singular.build-upload-singular.build-upload-singular[CO_URL]: CO_URL
+  -
+    type: end
+    name: end
+    title: End

--- a/pilotage/handler/webhook.go
+++ b/pilotage/handler/webhook.go
@@ -41,7 +41,7 @@ func WebHook(ctx *macaron.Context) (int, []byte) {
 
 	url := fmt.Sprintf("%s/flow/v1/%s/%s/%s/%s/%s", config.WebHook.Host, namespace, repository, flowName, tag, "yaml")
 
-	flowYamlPath := fmt.Sprintf("%s/%s/%s/%s/flow.yaml", config.WebHook.FlowBaseDir, namespace, repository, tag)
+	flowYamlPath := fmt.Sprintf("%s/%s/%s/%s.yml", config.WebHook.FlowBaseDir, namespace, repository, tag)
 	f := &module.Flow{}
 	if err := f.ParseFlowFromFile(flowYamlPath, module.DaemonRun, false, true); err != nil {
 		log.Error(err)


### PR DESCRIPTION
Add the subscriptions / outputs in cohook flow:
- co-code-changed component outputs `CO_CODE_CHANGED`
- co-code-build component subscribes `CO_CODE_CHANGED` output and determine whether to re-build the source code, if true, outputs `CO_URL`
- co-code-redeploy component subscribes `CO_CODE_CHANGED` and `CO_URL`, if the code is changed and the newly built binary's URL is provided, then redeploy the target project.