### PR TITLE
Add more args to build, fix some bugs

### DIFF
--- a/assembling/docs/api.md
+++ b/assembling/docs/api.md
@@ -21,6 +21,7 @@ POST  /assembling/build
 |namespace|string|Query|
 |image|string|Query|
 |tag|string|Query|
+|buildargs|json string|Query|
 |Dockerfile & archive file|binary|Body|
 
 > The body should be a single Dockerfile or, if some extra files are included, an archive file, which can be in the format of tar, gzip, bzip2 or xz, according to the [Docker Engine API](https://docs.docker.com/engine/api/v1.31/#operation/ImageBuild), section `REQUEST BODY`.
@@ -30,7 +31,7 @@ POST  /assembling/build
 - **Example**
 
 ```http
-POST /assembling/build?registry=hub.opshub.sh&namespace=containerops&image=ubuntu&tag=14.04
+POST /assembling/build?registry=hub.opshub.sh&namespace=containerops&image=ubuntu&tag=14.04&buildargs={"RELEASE":"1.0.1", "DEV_TAG":"FOXHOUND"}
 
 Body(Binary file)
 

--- a/assembling/handler/imagebuild.go
+++ b/assembling/handler/imagebuild.go
@@ -52,7 +52,7 @@ func BuildImageHandler(mctx *macaron.Context) (int, []byte) {
 	image := mctx.Req.Request.FormValue("image")
 	tag := mctx.Req.Request.FormValue("tag")
 	buildArgsJSON := mctx.Req.Request.FormValue("buildargs")
-	authStr := mctx.Req.Request.FormValue("authstr")
+	authstr := mctx.Req.Request.FormValue("authstr")
 
 	var buildArgs map[string]*string
 	if buildArgsJSON == "" {
@@ -128,6 +128,10 @@ func BuildImageHandler(mctx *macaron.Context) (int, []byte) {
 
 	// TODO Support pushing to registries that need authorization
 	// authStr, _ := generateAuthStr("", "")
+	authStr := authstr
+	if authStr == "" {
+		authStr, _ = generateAuthStr("", "")
+	}
 
 	log.Infof("Push image, id: %s", buildId)
 	if err := pushImage(ctx, dockerClient, registry, namespace, image, tag, authStr); err != nil {

--- a/assembling/handler/imagebuild.go
+++ b/assembling/handler/imagebuild.go
@@ -76,7 +76,7 @@ func BuildImageHandler(mctx *macaron.Context) (int, []byte) {
 
 	var tarfile io.Reader
 	if !isBodyDockerArchive {
-		tarfile, err = createTarFile(mctx.Req.Request.Body)
+		tarfile, err = createTarFile(buf)
 	} else {
 		tarfile = buf
 	}

--- a/assembling/handler/imagebuild.go
+++ b/assembling/handler/imagebuild.go
@@ -52,6 +52,7 @@ func BuildImageHandler(mctx *macaron.Context) (int, []byte) {
 	image := mctx.Req.Request.FormValue("image")
 	tag := mctx.Req.Request.FormValue("tag")
 	buildArgsJSON := mctx.Req.Request.FormValue("buildargs")
+	authStr := mctx.Req.Request.FormValue("authstr")
 
 	var buildArgs map[string]*string
 	if buildArgsJSON == "" {
@@ -122,7 +123,7 @@ func BuildImageHandler(mctx *macaron.Context) (int, []byte) {
 	}
 
 	// TODO Support pushing to registries that need authorization
-	authStr, _ := generateAuthStr("", "")
+	// authStr, _ := generateAuthStr("", "")
 
 	log.Infof("Push image, id: %s", buildId)
 	if err := pushImage(ctx, dockerClient, registry, namespace, image, tag, authStr); err != nil {


### PR DESCRIPTION
Add more args when calling assembling build:
- buildargs: JSON map of string pairs,  equivalent to `--build-arg` when calling `docker build` 
- authstr: The base64 encoded auth string, more detail [here](https://docs.docker.com/engine/api/v1.30/#operation/ImagePush)

Fix bugs:
- Failed to get `Dockerfile` content in the tar file. This is caused by the calling of http.Request.FormValue in golang. The FormValue method will parse the body as form, so the body is no longer kept in binary.
- Response 'Empty dockerfile' error when pass a single Dockerfile to build API. This is caused by calling http.Request.Body(which is io.Reader) twice.