### PR TITLE
Wait for host:port to be ready

### DIFF
--- a/singular/module/deployment.go
+++ b/singular/module/deployment.go
@@ -19,9 +19,9 @@ package module
 import (
 	"fmt"
 	"io"
-	"time"
 
 	"github.com/Huawei/containerops/common"
+	"github.com/Huawei/containerops/common/utils"
 	"github.com/Huawei/containerops/singular/model"
 	"github.com/Huawei/containerops/singular/module/infras"
 	"github.com/Huawei/containerops/singular/module/objects"
@@ -128,8 +128,20 @@ func DeployInfraStacks(d *objects.Deployment, db bool, stdout io.Writer, timesta
 				d.Nodes = append(d.Nodes, &node)
 			}
 
-			objects.WriteLog("sleep 60 second for preparing Droplets", stdout, timestamp, d, &do)
-			time.Sleep(60 * time.Second)
+			objects.WriteLog("Wait droplets to be ready(22 port on)", stdout, timestamp, d, &do)
+
+			waitChannel := make(chan error)
+			for _, node := range d.Nodes {
+				go func(node *objects.Node) {
+					// Try to dial the default ssh port on
+					waitChannel <- utils.WaitForHostPort(node.IP, tools.DefaultSSHPort, 10, 10)
+				}(node)
+			}
+			for i := 0; i < len(d.Nodes); i++ {
+				if err := <-waitChannel; err != nil {
+					return err
+				}
+			}
 
 			d.Service.Logs = do.Logs
 		default:
@@ -201,7 +213,7 @@ func DeployInfraStacks(d *objects.Deployment, db bool, stdout io.Writer, timesta
 					return err
 				}
 			default:
-				return fmt.Errorf("unsupport infrastruction software: %s", infra)
+				return fmt.Errorf("unsupport infrastruction software: %s", infra.Name)
 			}
 		}
 

--- a/singular/module/template/docker.go
+++ b/singular/module/template/docker.go
@@ -24,7 +24,7 @@ Documentation=http://docs.docker.io
   
 [Service]
 EnvironmentFile=-/run/flannel/docker
-ExecStart=/usr/local/bin/dockerd --log-level=error $DOCKER_NETWORK_OPTIONS
+ExecStart=/usr/local/bin/dockerd --log-level=error $DOCKER_NETWORK_OPTIONS --iptables=false
 ExecReload=/bin/kill -s HUP $MAINPID
 Restart=on-failure
 RestartSec=5


### PR DESCRIPTION
- Add the util to telnet a port on the host(with interval and retry times), when accessible, do the right thing.
- Add `--iptables=false` option in docker systemd service file, since when docker daemon starts, it will drop all other requests in FORWARD chain in iptables