### PR TITLE
Update the reference to "context" package.

### DIFF
--- a/singular/module/service/digitalocean.go
+++ b/singular/module/service/digitalocean.go
@@ -17,6 +17,7 @@ limitations under the License.
 package service
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -25,7 +26,6 @@ import (
 	"golang.org/x/oauth2"
 
 	"github.com/digitalocean/godo"
-	"github.com/digitalocean/godo/context"
 )
 
 const (


### PR DESCRIPTION
Use the "context" package from stdlib instead of digitalocean/godo.
Since digitalocean/godo has removed the support for go 1.6:
https://github.com/digitalocean/godo/commit/e6249e5059a7a003fd7c1db259e50826d43e8db3